### PR TITLE
修改repeat中组件不能使用静态属性的bug

### DIFF
--- a/packages/wepy-cli/src/compile-template.js
+++ b/packages/wepy-cli/src/compile-template.js
@@ -117,7 +117,7 @@ export default {
                 if (ignores[w] || this.isInQuote(matchs, n)) {
                     return match;
                 } else {
-                    if (mapping.items && mapping.items[w]) {
+                    if (mapping.items && mapping.items[w] && mapping.items[w].bind) {
                         // prefix 减少一层
                         let upper = prefix.split(PREFIX);
                         upper.pop();


### PR DESCRIPTION
用目前的代码会输出：
``` html
<image mode="aspectFit" src="{{../icons/icon_sound.png}}" />
``` 
会导致微信开发者工具文件编译错误