### PR TITLE
remove the aliasFields config in the template

### DIFF
--- a/packages/wepy-cli/templates/template/wepy.config.js
+++ b/packages/wepy-cli/templates/template/wepy.config.js
@@ -9,7 +9,10 @@ module.exports = {
     web: {
       htmlTemplate: path.join('src', 'index.template.html'),
       htmlOutput: path.join('web', 'index.html'),
-      jsOutput: path.join('web', 'index.js')
+      jsOutput: path.join('web', 'index.js'),
+      resolve: {
+        aliasFields: ['browser']
+      }
     }
   },
   resolve: {
@@ -17,6 +20,7 @@ module.exports = {
       counter: path.join(__dirname, 'src/components/counter'),
       '@': path.join(__dirname, 'src')
     },
+    aliasFields: ['wepy', 'weapp'],
     modules: ['node_modules']
   },
   compilers: {

--- a/packages/wepy-cli/templates/template/wepy.config.js
+++ b/packages/wepy-cli/templates/template/wepy.config.js
@@ -17,7 +17,6 @@ module.exports = {
       counter: path.join(__dirname, 'src/components/counter'),
       '@': path.join(__dirname, 'src')
     },
-    aliasFields: ['wepy'],
     modules: ['node_modules']
   },
   compilers: {


### PR DESCRIPTION
The aliasFields config in the template is removed in favor of the DEFAULT_ALIASFIELDS (`['wepy', 'weapp', 'browser']`).

This should resolve https://github.com/leancloud/javascript-sdk/pull/529

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
