### PR TITLE
fix: 支付宝小程序调用getAuthCode时，需要设置scopes参数为auth_user，为了尽可能抹平wepy.login方法在…

### DIFF
--- a/packages/wepy-ant/src/app.js
+++ b/packages/wepy-ant/src/app.js
@@ -135,7 +135,7 @@ export default class {
                                 obj = (typeof(obj) === 'string') ? {url: obj} : obj;
                             }
                             if (key === 'getAuthCode') {
-                                obj.scopes = 'auth_user'
+                                obj.scopes = obj.scopes || 'auth_user'
                             }
                             if (typeof obj === 'string') {
                                 return my[key](obj);

--- a/packages/wepy-ant/src/app.js
+++ b/packages/wepy-ant/src/app.js
@@ -134,6 +134,9 @@ export default class {
                             if (key === 'request') {
                                 obj = (typeof(obj) === 'string') ? {url: obj} : obj;
                             }
+                            if (key === 'getAuthCode') {
+                                obj.scopes = 'auth_user'
+                            }
                             if (typeof obj === 'string') {
                                 return my[key](obj);
                             }


### PR DESCRIPTION
支付宝小程序调用getAuthCode时，需要设置scopes参数为auth_user，为了尽可能抹平wepy.login方法在支付宝下区别与微信的地方，需要加上该FIX

##### Checklist
- [x ] `npm run test` passes
