### PR TITLE
修正 例子中展示结果错误

### DIFF
--- a/docs/md/doc.md
+++ b/docs/md/doc.md
@@ -1216,8 +1216,8 @@ export default class Index extends wepy.page {
     };
     mixins = [TestMixin ];
     onShow() {
-        console.log(this.foo); // foo defined by index.
-        console.log(this.bar); // foo defined by testMix.
+        console.log(this.foo); // foo defined by index
+        console.log(this.bar); // bar defined by testMix
     }
 }
 ```


### PR DESCRIPTION
默认混合模式例子中 访问 this.bar 应该返回 TestMixin  中的 bar, 即"bar defined by testMix" ; 另外注释中的 "." 没有必要，容易误解

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added

