### PR TITLE
fix npm scoped packages

### DIFF
--- a/packages/wepy-cli/src/compile-style.js
+++ b/packages/wepy-cli/src/compile-style.js
@@ -119,7 +119,12 @@ export default {
                         } else {
                             let mainFile = null;
                             let sepIndex = lib.indexOf(path.sep);
-                            if (sepIndex > 0) {
+                            if (lib.indexOf('@') === 0) { // for scoped npm deps
+                                let tempArr = lib.split('/')
+                                if (tempArr.length > 2) {
+                                    lib = tempArr[0] + path.sep + tempArr[1]
+                                }
+                            } else if (sepIndex > 0) {
                                 let tmp = lib;
                                 lib = tmp.substring(0, sepIndex);
                                 mainFile = tmp.substring(sepIndex + 1, tmp.length);

--- a/packages/wepy-cli/src/util.js
+++ b/packages/wepy-cli/src/util.js
@@ -139,7 +139,12 @@ const utils = {
             }
         }
         let lib = com, main = null;
-        if (com.indexOf(path.sep) > 0) {
+        if (com.indexOf('@') === 0) { // for scoped npm deps
+            let tempArr = com.split('/')
+            if (tempArr.length > 2) {
+                lib = tempArr[0] + path.sep + tempArr[1]
+            }
+        } else if (com.indexOf(path.sep) > 0) {
             let sepIndex = com.indexOf(path.sep);
             lib = com.substring(0, sepIndex);
             main = com.substring(sepIndex + 1, com.length);


### PR DESCRIPTION
##### Fixed

修复scope npm包require的问题。
scope npm包都是以`@`开头，如`@mnui/toptips`其实是一个npm包的名字，不应该直接用`/`去分割包名。

##### Checklist

- [x] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
