### PR TITLE
使用less的严格模式以避免对calc的错误计算

### DIFF
--- a/packages/wepy-cli/templates/empty/wepy.config.js
+++ b/packages/wepy-cli/templates/empty/wepy.config.js
@@ -6,7 +6,8 @@ module.exports = {
   cliLogs: !isProd,
   compilers: {
     less: {
-      'compress': isProd
+      'compress': isProd,
+      'strictMath': true
     },
     // sass: {
     //   outputStyle: 'compressed'

--- a/packages/wepy-cli/templates/template/wepy.config.js
+++ b/packages/wepy-cli/templates/template/wepy.config.js
@@ -25,7 +25,8 @@ module.exports = {
   },
   compilers: {
     less: {
-      compress: isProd
+      compress: isProd,
+      strictMath: true
     },
     // sass: {
     //   outputStyle: 'compressed'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

仅仅在wepy-cli的模板代码中添加一个less的配置strictMath，解决默认情况下less忽略calc中表达式的单位强制计算的问题。比如calc(100vh - 80px)会编译成calc(20vh)。这个问题已经有人提出[issue](https://github.com/Tencent/wepy/issues/340)了
该配置具体说明参考[这里](https://less.bootcss.com/usage/#less-options-cross-platform-options)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
