### PR TITLE
依赖处理跳过注释&require路径支持省略./

### DIFF
--- a/packages/wepy-cli/src/util.js
+++ b/packages/wepy-cli/src/util.js
@@ -641,10 +641,29 @@ const utils = {
                         offset--;
                     break;
                 case '/':
-                    if (code[offset - 1] === '/') {
-                        return true;
-                    } else if (starFound)
-                        return true;
+                    if ((code[offset - 1] === '/') || starFound) {
+                        // check if it's in a string
+                        const searchRegexp = /`|'|"|`/g;
+                        let single = false;
+                        let regexp = searchRegexp;
+                        let lastIndex = 0;
+                        while(true) {
+                            const res = regexp.exec(code);
+                            lastIndex = regexp.lastIndex;
+                            if (res && (lastIndex <= offset)) {
+                                single = !single;
+                                if (single) {
+                                    regexp = new RegExp(res, 'g');
+                                } else {
+                                    regexp = searchRegexp;
+                                }
+                                regexp.lastIndex = lastIndex;
+                            } else {
+                                break;
+                            }
+                        }
+                        return !single;
+                    }
                 default:
                     starFound = false;
                     offset--;

--- a/packages/wepy-cli/src/util.js
+++ b/packages/wepy-cli/src/util.js
@@ -618,6 +618,39 @@ const utils = {
             ID_CACHE[filepath] = '_' + hash(filepath).slice(1, 8);
         }
         return ID_CACHE[filepath];
+    },
+    checkComment(code, offset) {
+        // check if it is a comment
+        let starFound = false;
+        while (offset >= 0) {
+            const char = code[offset];
+            switch (char) {
+                case '*':
+                    starFound = true;
+                    offset--;
+                    break;
+                case '\t':
+                case ' ':
+                    offset--;
+                    break;
+                case '\r':
+                case '\n':
+                    if (!starFound)
+                        offset = -1;
+                    else
+                        offset--;
+                    break;
+                case '/':
+                    if (code[offset - 1] === '/') {
+                        return true;
+                    } else if (starFound)
+                        return true;
+                default:
+                    starFound = false;
+                    offset--;
+            }
+        }
+        return false;
     }
 }
 export default utils

--- a/packages/wepy-cli/test/util.js
+++ b/packages/wepy-cli/test/util.js
@@ -62,6 +62,15 @@ describe('util.js', () => {
 
             assert.strictEqual(util.checkComment(code, code.length - 1), expect)
         });
+        it('comment in string', () => {
+
+            const codes = ['"// require("foo")"', '"/* require("foo") */"'];
+            const expect = false;
+
+            codes.forEach((code) => {
+                assert.strictEqual(util.checkComment(code, code.length - 1), expect)
+            });
+        });
     });
 
 });

--- a/packages/wepy-cli/test/util.js
+++ b/packages/wepy-cli/test/util.js
@@ -30,4 +30,38 @@ describe('util.js', () => {
             assert.strictEqual(util.attrReplace(capture), expect)
         });
     })
+
+    describe('checkComment', () => {
+        it('/* comment', () => {
+
+            const code = '/** require("foo") */';
+            const expect = true;
+
+            assert.strictEqual(util.checkComment(code, code.length - 1), expect)
+        });
+
+        it('/* comment with enter', () => {
+
+            const code = '/** foo\n * require("bar")\n */';
+            const expect = true;
+
+            assert.strictEqual(util.checkComment(code, code.length - 1), expect)
+        });
+
+        it('// comment', () => {
+
+            const code = '// require("foo")';
+            const expect = true;
+
+            assert.strictEqual(util.checkComment(code, code.length - 1), expect)
+        });
+        it('no comment', () => {
+
+            const code = 'require("foo")';
+            const expect = false;
+
+            assert.strictEqual(util.checkComment(code, code.length - 1), expect)
+        });
+    });
+
 });


### PR DESCRIPTION
迁移现有小程序时发现：
- js代码的注释中如果存在require，会参与依赖处理，如路径不存在时，编译会报错：
```javascript
/* require('../foo/bar') */
// require('../foo/bar')
```
- 微信开发者工具支持require当前路径时省略./，但在wepy中会当成npm包，找不到时会报错，如：
```javascript
// 相当于require('./foo/bar')
require('foo/bar')
```

本PR解决以上问题：
1. require存在于注释中则跳过，不参与依赖处理。
1. 形如require('foo/bar')，若没有相应npm包，则在本地目录查找。
