### PR TITLE
修改请求拦截器逻辑，用户可以中断后续代码执行

### DIFF
--- a/packages/wepy/src/app.js
+++ b/packages/wepy/src/app.js
@@ -181,10 +181,13 @@ export default class {
                                             if (self.$interceptors[key] && self.$interceptors[key][k]) {
                                                 res = self.$interceptors[key][k].call(self, res);
                                             }
-                                            if (k === 'success')
-                                                resolve(res);
-                                            else if (k === 'fail')
-                                                reject(res);
+                                            // 如果用户在自定义请求拦截器的success函数里面没有返回response对象，则不执行后续代码了
+                                            if(res){
+                                                if (k === 'success')
+                                                    resolve(res);
+                                                else if (k === 'fail')
+                                                    reject(res);
+                                            }
                                         };
                                     });
                                     if (self.$addons.requestfix && key === 'request') {
@@ -213,7 +216,7 @@ export default class {
                                         if (self.$interceptors[key] && self.$interceptors[key][k]) {
                                             res = self.$interceptors[key][k].call(self, res);
                                         }
-                                        bak[k] && bak[k].call(self, res);
+                                        res && bak[k] && bak[k].call(self, res);
                                     };
                                 });
                                 if (self.$addons.requestfix && key === 'request') {


### PR DESCRIPTION
<!--
上面的修改是为了满足这么一个需求，我希望在request拦截器里面对服务端返回的状态做处理，比如服务端返回401未授权，说明可能没有登陆，那么我直接可以在  自定义的拦截器的success方法里对这一行为进行处理，处理完毕后wepy.request的then方法就没有必要再去调用，因为成功了才去调用

所谓拦截器，我觉得至少满足这2个需求：
1.能在某个行为前拦截，插入自定义行为
2.拦截后能决定是否终止往下执行，是否放行
-->

页面代码：
```javascript
     wepy.request({
        url: 'https://baidu.com',
        method: 'POST',
        data: {
          username: this.username,
          password: this.password
        }
      }).then(res => {
        //成功后会执行的函数
      })
```

拦截器：
```javascript
success (resp) {
    switch (resp.statusCode) {
      case 200:
        console.log('200')
        break
      case 403:
        console.log('未授权,在这里跳转到登陆页，同时希望页面代码的success不再继续执行')
        return
    }
    return resp
  },
```
