### PR TITLE
remove useless exports from wepy-redux

### DIFF
--- a/packages/wepy-redux/src/index.js
+++ b/packages/wepy-redux/src/index.js
@@ -10,12 +10,9 @@
 
 import connect from './connect';
 import { setStore, getStore } from './store';
-import { mapState, mapActions } from './helpers';
 
 export {
     connect,
     setStore,
-    getStore,
-    mapState,
-    mapActions
+    getStore
 }


### PR DESCRIPTION
wepy-redux中导出的helpers没有用处，所以去掉