### PR TITLE
修复repeat组件for="{{[var1,var2]}}"时的数据绑定问题，以及组件内capture事件问题修复

### DIFF
--- a/packages/wepy-cli/src/compile-template.js
+++ b/packages/wepy-cli/src/compile-template.js
@@ -283,7 +283,7 @@ export default {
                 }
                 // bindtap="abc" => bindtap="prefix_abc"
                 if (
-                    (config.output !== 'ant' && (attr.name.indexOf('bind') === 0 || attr.name.indexOf('catch') === 0)) ||
+                    (config.output !== 'ant' && (attr.name.indexOf('bind') === 0 || attr.name.indexOf('catch') === 0 || attr.name.indexOf('capture') === 0)) ||
                     (config.output === 'ant' && (attr.name.indexOf('on') === 0 || attr.name.indexOf('catch') === 0))
                     ) {
                     // added index for all events;

--- a/packages/wepy/src/component.js
+++ b/packages/wepy/src/component.js
@@ -1,7 +1,7 @@
 /**
  * Tencent is pleased to support the open source community by making WePY available.
  * Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
- * 
+ *
  * Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  * http://opensource.org/licenses/MIT
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
@@ -148,7 +148,7 @@ export default class {
                             props[key].index = binded.index;
                             props[key].key = binded.key;
                             props[key].value = binded.value;
-                            
+
                             inRepeat = true;
 
                             let bindfor = binded.for, binddata = $parent;
@@ -294,9 +294,26 @@ export default class {
                     if (binded) {
                         if (typeof(binded) === 'object') {
                             let bindfor = binded.for, binddata = $parent;
-                            bindfor.split('.').forEach(t => {
-                                binddata = binddata ? binddata[t] : {};
-                            });
+
+                            // 处理 for="{{[var1,var2]}}"
+                            if (bindfor.indexOf('[') === 0) {
+                                let bdarr = [];
+                                bindfor = bindfor.substr(1, bindfor.length - 2).trim()
+
+                                bindfor.split(',').forEach(function (e) {
+                                    let bd = $parent;
+                                    e.trim().split('.').forEach(function (t) {
+                                        bd = bd ? bd[t] : {};
+                                    })
+                                    bdarr.push(bd)
+                                })
+
+                                binddata = bdarr
+                            } else {
+                                bindfor.split('.').forEach(t => {
+                                    binddata = binddata ? binddata[t] : {};
+                                });
+                            }
 
                             index = Array.isArray(binddata) ? +index : index;
 
@@ -540,7 +557,7 @@ export default class {
                         }
                     }
                     // Send to ReadyToSet
-                    readyToSet[this.$prefix + k] = this[k]; 
+                    readyToSet[this.$prefix + k] = this[k];
                     this.data[k] = this[k];
                     originData[k] = util.$copy(this[k], true);
                     if (this.$repeat && this.$repeat[k]) {


### PR DESCRIPTION
在循环组件中为了让子组件也能动态绑定，按照 @coolhwm 的建议 #1012 采用<repeat>循环数组的方式让子组件能动态绑定数据
但是有个问题，子组件中method方法无法工作，因为不能正确处理 <code>"[data]"</code> 这样的绑定

像下面这样，onTap将无法工作。因此对组件<code>$setIndex</code>做了些改进。

```xml
<!-- parent.wpy -->
<repeat for="{{ [ data ] }}" item="data" index="i" key="i">
   <child :data.sync="data"></child>
</repeat>
```

```xml
<!-- child.wpy  -->
<template>
     <view @tap="onTap({{data}}">点我</view>
</template>
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
