### PR TITLE
support mixin extends another mixin

### DIFF
--- a/packages/wepy/src/mixin.js
+++ b/packages/wepy/src/mixin.js
@@ -29,7 +29,8 @@ export default class {
         // support mixin extends another mixin
         do {
             props.push(...Object.getOwnPropertyNames(obj));
-        } while (obj = Object.getPrototypeOf(obj));
+            obj = Object.getPrototypeOf(obj);
+        } while (Object.getPrototypeOf(obj));
 
         // 自定义属性覆盖
         props.forEach((k) => {

--- a/packages/wepy/src/mixin.js
+++ b/packages/wepy/src/mixin.js
@@ -22,14 +22,21 @@ export default class {
     $init (parent) {
         let k;
 
+        let props = [];
+        let obj = this;
+
+        // Recursively get own and prototype properties
+        // support mixin extends another mixin
+        do {
+            props.push(...Object.getOwnPropertyNames(obj));
+        } while (obj = Object.getPrototypeOf(obj));
+
         // 自定义属性覆盖
-        Object.getOwnPropertyNames(this)
-            .concat(Object.getOwnPropertyNames(Object.getPrototypeOf(this)))
-            .forEach((k) => {
-                if (k[0] + k[1] !== 'on' && k !== 'constructor') {
-                    if (!parent[k])
-                        parent[k] = this[k];
-                }
+        props.forEach((k) => {
+            if (k[0] + k[1] !== 'on' && k !== 'constructor') {
+                if (!parent[k])
+                    parent[k] = this[k];
+            }
         });
 
 


### PR DESCRIPTION
支持mixin的继承，修复https://github.com/Tencent/wepy/issues/1068
使得
1. mixin上使用@connect时，不破坏属性的混入
2. mixin可以通过继承扩展