### PR TITLE
fix typo, rename .DB_S(s)tore to .DS_Store

### DIFF
--- a/packages/wepy-cli/templates/empty/.wepyignore
+++ b/packages/wepy-cli/templates/empty/.wepyignore
@@ -1,4 +1,4 @@
 node_modules
 dist
-.DB_store
+.DS_Store
 *.wpy___jb_tmp___

--- a/packages/wepy-cli/templates/empty/gitignore
+++ b/packages/wepy-cli/templates/empty/gitignore
@@ -1,3 +1,3 @@
 node_modules
 dist
-.DB_store
+.DS_Store

--- a/packages/wepy-cli/templates/template/.wepyignore
+++ b/packages/wepy-cli/templates/template/.wepyignore
@@ -1,4 +1,4 @@
 node_modules
 dist
-.DB_store
+.DS_Store
 *.wpy___jb_tmp___

--- a/packages/wepy-cli/templates/template/gitignore
+++ b/packages/wepy-cli/templates/template/gitignore
@@ -1,3 +1,3 @@
 node_modules
 dist
-.DB_store
+.DS_Store


### PR DESCRIPTION
修复.gitignore和.wepyignore中的输入错误

.DB_store应该是.DS_Store