### PR TITLE
Add fileName to typescript compiler config

### DIFF
--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -233,7 +233,7 @@ export default {
             return;
         }
         
-        const compileConfig = config.compiler[lang] || {};
+        const compileConfig = Object.assign({}, config.compiler[lang] || {});
         
         // typescript compiler need the filename to generate right sourcemap
         // https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#transpiling-a-single-file

--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -232,8 +232,16 @@ export default {
         if (!compiler) {
             return;
         }
+        
+        const compileConfig = config.compiler[lang] || {};
+        
+        // typescript compiler need the filename to generate right sourcemap
+        // https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#transpiling-a-single-file
+        if (lang === 'typescript') {
+            compileConfig.fileName = opath.base;
+        }
 
-        compiler(code, config.compilers[lang] || {}).then(compileResult => {
+        compiler(code, compileConfig).then(compileResult => {
             let sourceMap;
             if (typeof(compileResult) === 'string') {
                 code = compileResult;


### PR DESCRIPTION
When compiling typescript scripts, the compiler need to know the file name of the original one to generate the right sourcemap.

##### Checklist
*You do not have any test for compile-script yet*
- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
