### PR TITLE
增加 羽球自由对阵赛 项目

### DIFF
--- a/docs/data/cases.json
+++ b/docs/data/cases.json
@@ -355,6 +355,13 @@
             "opensource": "",
             "qrcode": "",
             "company": ""
-       }
+        }, {
+            "name": "羽球自由对阵赛",
+            "email": "1648511816@qq.com",
+            "link": "",
+            "opensource": "https://github.com/jasscia/newBadminton",
+            "qrcode": "https://raw.githubusercontent.com/jasscia/newBadminton/master/src/image/scancode.jpg",
+            "company": ""
+        }
     ]
 }


### PR DESCRIPTION
是一个适用于 羽毛球业余团体 组织团队日常活动的助手，辅助召集报名 报名后生成对阵表 计分 和排名等

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
