### PR TITLE
完善对 require 关键词的识别准确度

### DIFF
--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -29,7 +29,7 @@ export default {
         let wpyExt = params.wpyExt;
 
 
-        return code.replace(/require\(['"]([\w\d_\-\.\/@]+)['"]\)/ig, (match, lib) => {
+        return code.replace(/\s+require\(['"]([\w\d_\-\.\/@]+)['"]\)/ig, (match, lib) => {
             let npmInfo = opath.npm;
 
             if (lib === './_wepylogs.js') {


### PR DESCRIPTION
原代码遇到 lodash 中的 `var types = freeModule && freeModule.require && freeModule.require('util').types;` 会误认为这里存在 `require('util')` ，然而这里的 `require` 只不过是个普通方法。