### PR TITLE
添加eslint对扩展文件的支持，例如js/es/ts等

### DIFF
--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -14,7 +14,7 @@ import cache from './cache';
 import cWpy from './compile-wpy';
 
 import loader from './loader';
-
+import eslint from './eslint';
 import resolve from './resolve';
 
 
@@ -215,16 +215,23 @@ export default {
     },
 
     compile (lang, code, type, opath) {
+        const filepath = path.join(opath.dir, opath.base);
+        
         let config = util.getConfig();
         src = cache.getSrc();
         dist = cache.getDist();
         npmPath = path.join(currentPath, dist, 'npm' + path.sep);
 
         if (!code) {
-            code = util.readFile(path.join(opath.dir, opath.base));
+            code = util.readFile(filepath);
             if (code === null) {
-                throw '打开文件失败: ' + path.join(opath.dir, opath.base);
+                throw '打开文件失败: ' + filepath;
             }
+        }
+        
+        const suffix = filepath.substr(filepath.lastIndexOf('.'));
+        if (config.eslintExt && ~config.eslintExt.indexOf(suffix)) {
+            eslint(filepath);
         }
 
         let compiler = loader.loadCompiler(lang);


### PR DESCRIPTION
添加eslint对扩展文件的支持，例如js/es/ts等

add eslintExt config

配置方式如下
```js
const config = {
  wpyExt: '.wpy',
  eslint: true,
  eslintExt: '.js',
  // eslintExt: ['.js', '.ts'],
}
```js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
