### PR TITLE
Change all instances of +new Date() to new Date.getTime()

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ WePY (发音: /'wepi/)是一款让小程序支持组件化开发的框架，通�
             myprop: {}
         };
         computed = {
-            now () { return +new Date(); }
+            now () { return new Date().getTime(); }
         };
         async onLoad() {
             await sleep(3);

--- a/docs/md/api.md
+++ b/docs/md/api.md
@@ -68,7 +68,7 @@ export class App extends wepy.app {
         super();
         this.intercept('request', {
             config (p) {
-                p.timestamp = +new Date();
+                p.timestamp = new Date().getTime();
                 return p;
             },
             success (obj) {

--- a/docs/md/doc.md
+++ b/docs/md/doc.md
@@ -1380,7 +1380,7 @@ export default class extends wepy.app {
             // 发出请求时的回调函数
             config (p) {
                 // 对所有request请求中的OBJECT参数对象统一附加时间戳属性
-                p.timestamp = +new Date();
+                p.timestamp = new Date().getTime();
                 console.log('config request: ', p);
                 // 必须返回OBJECT参数对象，否则无法发送请求到服务端
                 return p;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5280,11 +5280,6 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "hoek": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
-      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",

--- a/packages/wepy-ant/src/app.js
+++ b/packages/wepy-ant/src/app.js
@@ -15,7 +15,7 @@ let RequestMQ = {
     running: [],
     MAX_REQUEST: 5,
     push (param) {
-        param.t = +new Date();
+        param.t = new Date().getTime();
         while ((this.mq.indexOf(param.t) > -1 || this.running.indexOf(param.t) > -1)) {
             param.t += Math.random() * 10 >> 0;
         }

--- a/packages/wepy-cli/templates/template/src/pages/index-redux.wpy
+++ b/packages/wepy-cli/templates/template/src/pages/index-redux.wpy
@@ -177,7 +177,7 @@
 
     computed = {
       now () {
-        return +new Date()
+        return new Date().getTime()
       }
     }
 

--- a/packages/wepy-cli/templates/template/src/pages/index.wpy
+++ b/packages/wepy-cli/templates/template/src/pages/index.wpy
@@ -161,7 +161,7 @@
 
     computed = {
       now () {
-        return +new Date()
+        return new Date().getTime()
       }
     }
 

--- a/packages/wepy/src/app.js
+++ b/packages/wepy/src/app.js
@@ -16,7 +16,7 @@ let RequestMQ = {
     running: [],
     MAX_REQUEST: 10,
     push (param) {
-        param.t = +new Date();
+        param.t = new Date().getTime();
         while ((this.mq.indexOf(param.t) > -1 || this.running.indexOf(param.t) > -1)) {
             param.t += Math.random() * 10 >> 0;
         }

--- a/packages/wepy/test/component.js
+++ b/packages/wepy/test/component.js
@@ -111,7 +111,7 @@ describe('component.js', () => {
 
     it('$nextTick', function (done) {
         //this.timeout(1500);
-        com.a = +new Date();
+        com.a = new Date().getTime();
         com.$nextTick(function () {
             assert.strictEqual(this, com, 'setData callback use this');
             setTimeout(function () {
@@ -124,7 +124,7 @@ describe('component.js', () => {
 
     it('$nextTick using promise', function (done) {
         //this.timeout(1500);
-        com.a = +new Date();
+        com.a = new Date().getTime();
         com.$nextTick().then(function () {
             setTimeout(function () {
                 assert.strictEqual(com.$$nextTick, null, '$$nextTick should be cleared');
@@ -136,7 +136,7 @@ describe('component.js', () => {
 
     it('$nextTick callback for clear data', function (done) {
         //this.timeout(1500);
-        com.a = +new Date();
+        com.a = new Date().getTime();
         com.$apply();
         com.$nextTick(function () {
             assert.strictEqual(this, com, 'setData callback use this');
@@ -150,7 +150,7 @@ describe('component.js', () => {
 
     it('$nextTick using promise for clear data', function (done) {
         //this.timeout(1500);
-        com.a = +new Date();
+        com.a = new Date().getTime();
         com.$apply();
         com.$nextTick().then(function () {
             setTimeout(function () {
@@ -164,14 +164,14 @@ describe('component.js', () => {
 
     it('$nextTick do apply', function (done) {
         //this.timeout(1500);
-        com.a = +new Date();
+        com.a = new Date().getTime();
         com.$nextTick(function () {
             assert.strictEqual(this, com, 'setData callback use this');
-            com.a = +new Date();
+            com.a = new Date().getTime();
             com.$apply();
             com.$nextTick(function () {
                 assert.strictEqual(this, com, 'setData callback use this');
-                com.a = +new Date();
+                com.a = new Date().getTime();
                 com.$apply();
                 done();
             });


### PR DESCRIPTION
`new Date.getTime()` is significantly faster than `+new Date()`
and functionally equivalent

I'm sorry, my Chinese isn't very good, feel free to let me know if I am violating contribution guidelines.

Note that, as of when I forked this repo, `npm run test` had ~100 failures, so I did not fix those. 

Please see https://jsperf.com/new-date-timing for evidence that `+new Date()` is slow, and that `new Date.getTime()` is the fastest way to get a date number. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes 
- [x] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [x] documentation is changed or added
