### PR TITLE
Update doc.md

### DIFF
--- a/docs/md/doc.md
+++ b/docs/md/doc.md
@@ -881,7 +881,7 @@ project
 
 <template>
     <!-- 注意，使用for属性，而不是使用wx:for属性 -->
-    <repeat for="{{list}}" key="index" index="index" item="item">
+    <repeat for="{{list}}" key="id" index="index" item="item">
         <!-- 插入<script>脚本部分所声明的child组件，同时传入item -->
         <child :item="item"></child>
     </repeat>


### PR DESCRIPTION
由于repeat中的key值没有明确赋值规则故理解为与官方wx:key规则一致，官方wx:key的值以两种形式提供
1. 字符串，代表在 for 循环的 array 中 item 的某个 property，该 property 的值需要是列表中唯一的字符串或数字，且不能动态改变。
2. 保留关键字 *this 代表在 for 循环中的 item 本身，这种表示需要 item 本身是一个唯一的字符串或者数字

因为例子中的
```
data = {
            list: [{id: 1, title: 'title1'}, {id: 2, title: 'title2'}]
 }
```
并不包含index属性，故`key="index"` => `key="id"`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
