### PR TITLE
fix: 解决由传入pretty-data的值为null时，引起的打包异常

### DIFF
--- a/packages/wepy-plugin-filemin/src/index.js
+++ b/packages/wepy-plugin-filemin/src/index.js
@@ -36,9 +36,9 @@ export default class {
             });
 
             if (/\.(wxml|xml)$/.test(op.file)) {
-                op.code = pd.xmlmin(op.code);
+                op.code = pd.xmlmin(op.code || '');
             } else if (/\.json$/.test(op.file)) {
-                op.code = pd.jsonmin(op.code);
+                op.code = pd.jsonmin(op.code || '');
             }
             op.next();
         }


### PR DESCRIPTION
```
/mnt/hgfs/webprojects/guevara/node_modules/pretty-data/pretty-data.js:294
                                   : text.replace(/\<![ \r\n\t]*(--([^\-]|[\r\n]|-[^\-])*--[ \r\n\t]*)\>/g,"");
```
解决打包异常
