### PR TITLE
修复两级页面为同一路由时，后者数据覆盖前者

### DIFF
--- a/packages/wepy/src/base.js
+++ b/packages/wepy/src/base.js
@@ -180,7 +180,7 @@ export default {
 
                 self.$instance.__route__ = pageId;
                 self.$instance.__wxWebviewId__ = webViewId;
-
+                page.$resetData();
                 [].concat(page.$mixins, page).forEach((mix) => {
                     mix['onRoute'] && mix['onRoute'].apply(page, args);
                 });

--- a/packages/wepy/src/component.js
+++ b/packages/wepy/src/component.js
@@ -218,6 +218,21 @@ export default class {
             });
         }
     }
+    $resetData() {
+      let k;
+      let pages = getCurrentPages();
+      let _resetData = pages[pages.length - 1].data;
+      for (k in this.data) {
+        this[k] = _resetData[this.$prefix + k];
+      }
+      let coms = Object.getOwnPropertyNames(this.$com);
+      if (coms.length) {
+        coms.forEach((name) => {
+          const com = this.$com[name];
+          com.$resetData();
+        });
+      }
+    }
 
     $initMixins () {
         if (this.mixins) {


### PR DESCRIPTION
提供一个方案 修复两级页面为同一路由时，后者数据覆盖前者

修复issues : https://github.com/Tencent/wepy/issues/322