### PR TITLE
添加eslint对扩展文件的支持，例如js/es/ts等

### DIFF
--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -230,7 +230,8 @@ export default {
         }
         
         const suffix = filepath.substr(filepath.lastIndexOf('.'));
-        if (config.eslintExt && ~config.eslintExt.indexOf(suffix) && !~config.wpyExt.indexOf(opath.ext)) {
+        const { eslintExt = '', wpyExt } = config;
+        if (~eslintExt.indexOf(suffix) && !~wpyExt.indexOf(opath.ext)) {
             eslint(filepath);
         }
 

--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -14,7 +14,7 @@ import cache from './cache';
 import cWpy from './compile-wpy';
 
 import loader from './loader';
-
+import eslint from './eslint';
 import resolve from './resolve';
 
 
@@ -215,16 +215,23 @@ export default {
     },
 
     compile (lang, code, type, opath) {
+        const filepath = path.join(opath.dir, opath.base);
+        
         let config = util.getConfig();
         src = cache.getSrc();
         dist = cache.getDist();
         npmPath = path.join(currentPath, dist, 'npm' + path.sep);
 
         if (!code) {
-            code = util.readFile(path.join(opath.dir, opath.base));
+            code = util.readFile(filepath);
             if (code === null) {
-                throw '打开文件失败: ' + path.join(opath.dir, opath.base);
+                throw '打开文件失败: ' + filepath;
             }
+        }
+        
+        const suffix = filepath.substr(filepath.lastIndexOf('.'));
+        if (config.eslintExt && ~config.eslintExt.indexOf(suffix) && !~config.wpyExt.indexOf(opath.ext)) {
+            eslint(filepath);
         }
 
         let compiler = loader.loadCompiler(lang);

--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -228,10 +228,9 @@ export default {
                 throw '打开文件失败: ' + filepath;
             }
         }
-        
-        const suffix = filepath.substr(filepath.lastIndexOf('.'));
+
         const { eslintExt = '', wpyExt } = config;
-        if (~eslintExt.indexOf(suffix) && !~wpyExt.indexOf(opath.ext)) {
+        if (~eslintExt.indexOf(opath.ext) && !~wpyExt.indexOf(opath.ext)) {
             eslint(filepath);
         }
 


### PR DESCRIPTION
添加eslint对扩展文件的支持，例如js/es/ts等

add eslintExt config

配置方式如下
```js
const config = {
  wpyExt: '.wpy',
  eslint: true,
  eslintExt: '.js',
  // eslintExt: ['.js', '.ts'],
}
```js