### PR TITLE
fix(wepy-web): fix style inject sort (#1645)

### DIFF
--- a/packages/wepy-web/src/base.js
+++ b/packages/wepy-web/src/base.js
@@ -18,6 +18,9 @@ import {camelize, hyphenate} from './helper/word';
 const pageEvent = ['onLoad', 'onReady', 'onShow', 'onHide', 'onUnload', 'onPullDownRefresh', 'onReachBottom', 'onShareAppMessage'];
 
 const addStyle = (stylelist) => {
+    // fix style inject sort, https://github.com/Tencent/wepy/issues/1645
+    stylelist = stylelist.reverse()
+    
     let styleElement = document.createElement('style');
     let head = document.head || document.getElementsByTagName('head')[0];
 


### PR DESCRIPTION
##### Checklist
- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

##### Description
toweb编译过程中，是先编译wpy，再编译vue组件，导致stylelist队列中vue组件中的style索引值相对wpy的靠后，最终导致的结果是：在runtime中，生成inject style的时候，wpy中的class样式会被vue组件中默认样式覆盖，具体重现见对应issue

解决方式：反转stylelist队列，使vue组件默认样式排在wpy之前