### PR TITLE
chore(git): add git commit-msg hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "watch": "node ./node_modules/gulp/bin/gulp watch",
     "test": "./scripts/test.sh",
     "clean": "./scripts/clean.sh",
-    "publish": "npm run test && ./node_modules/.bin/lerna publish"
+    "publish": "npm run test && ./node_modules/.bin/lerna publish",
+    "commit": "git cz"
   },
   "repository": {
     "type": "git",
@@ -36,6 +37,8 @@
     "babel-preset-stage-1": "^6.16.0",
     "chai": "^4.1.2",
     "chalk": "^1.1.3",
+    "commitizen": "^2.10.1",
+    "cz-conventional-changelog": "^2.1.0",
     "eslint": "^3.11.1",
     "event-stream": "^3.3.4",
     "fs-extra": "^5.0.0",
@@ -48,6 +51,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.11",
+    "husky": "^1.0.0-rc.13",
     "istanbul": "^0.4.5",
     "jsonlint": "^1.6.2",
     "lerna": "^2.8.0",
@@ -58,7 +62,8 @@
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-replace": "^2.0.0",
     "serve-static": "^1.11.1",
-    "through2": "^2.0.3"
+    "through2": "^2.0.3",
+    "validate-commit-msg": "^2.14.0"
   },
   "babel": {
     "comments": false,
@@ -84,5 +89,32 @@
       }
     }
   },
-  "dependencies": {}
+  "dependencies": {},
+  "husky": {
+    "hooks": {
+      "commit-msg": "npx validate-commit-msg"
+    }
+  },
+  "config": {
+    "validate-commit-msg": {
+      "helpMessage": "\nPlease fix your commit message (and consider using http://npm.im/commitizen)\n",
+      "types": [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "chore",
+        "revert",
+        "custom"
+      ],
+      "warnOnFail": false,
+      "autoFix": true
+    },
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
 }


### PR DESCRIPTION
##### Checklist

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

##### Description

在 commit-msg 阶段对 commit message 做了标准化校验，不符合标准将不能提交，同时提供了相应的工具命令: ```npm run commit```，可方便地提交标准化的 message
