### PR TITLE
support plugins in array

### DIFF
--- a/packages/wepy-cli/src/loader.js
+++ b/packages/wepy-cli/src/loader.js
@@ -114,20 +114,26 @@ export default {
     },
 
     loadPlugin(plugins, op) {
-        let plg, plgkey, setting, config;
-        for (plgkey in plugins) {
-            let name = 'wepy-plugin-' + plgkey;
-            setting = plugins[plgkey];
-            plg = this.load(name);
+        if (util.isArray(plugins)) {
+            loadedPlugins = loadedPlugins.concat(plugins);
+            return true;
+        } else {
+            let plg, plgkey, setting, config;
+            for (plgkey in plugins) {
+                let name = 'wepy-plugin-' + plgkey;
+                setting = plugins[plgkey];
+                plg = this.load(name);
 
-            if (!plg) {
-                this.missingNPM = name;
-                util.log(`找不到插件：${name}。`, 'warning');
-                return false;
+                if (!plg) {
+                    this.missingNPM = name;
+                    util.log(`找不到插件：${name}。`, 'warning');
+                    return false;
+                }
+                loadedPlugins.push(new plg(setting));
             }
-            loadedPlugins.push(new plg(setting));
+            return true;
         }
-        return true;
+        
     },
     PluginHelper: PluginHelper
 }


### PR DESCRIPTION
支持plugins以数组的形式传入 这样可以支持外部插件的使用 而不是依赖于npm 因为很多公司级的私有npm仓库有私有前缀
