### PR TITLE
feat(core): added global mixin api

### DIFF
--- a/packages/core/dist/wepy.js
+++ b/packages/core/dist/wepy.js
@@ -1963,6 +1963,8 @@ var config$1 = {
   }
 };
 
+var globalMixinPatched = false;
+
 var defaultStrat = function (parentVal, childVal) { return childVal ? childVal : parentVal; };
 var strats = null;
 
@@ -2001,6 +2003,12 @@ function initStrats () {
 function patchMixins (output, option, mixins) {
   if (!mixins) {
     return;
+  }
+
+  if (!globalMixinPatched) {
+    var globalMixin = $global.mixin || {};
+    mixins = [].concat(mixins).concat(globalMixin);
+    globalMixinPatched = true;
   }
 
   if (isArr(mixins)) {
@@ -2090,6 +2098,12 @@ function use (plugin) {
   plugin.installed = 1;
 }
 
+function mixin (options) {
+  if ( options === void 0 ) options = {};
+
+  $global.mixin = options;
+}
+
 var wepy = Base;
 
 Object.assign(wepy, {
@@ -2099,7 +2113,8 @@ Object.assign(wepy, {
   global: $global,
 
   // global apis
-  use: use
+  use: use,
+  mixin: mixin
 });
 
 module.exports = wepy;

--- a/packages/core/dist/wepy.js
+++ b/packages/core/dist/wepy.js
@@ -2007,7 +2007,7 @@ function patchMixins (output, option, mixins) {
 
   if (!globalMixinPatched) {
     var globalMixin = $global.mixin || {};
-    mixins = [].concat(mixins).concat(globalMixin);
+    mixins = [globalMixin].concat(mixins);
     globalMixinPatched = true;
   }
 
@@ -2101,7 +2101,19 @@ function use (plugin) {
 function mixin (options) {
   if ( options === void 0 ) options = {};
 
-  $global.mixin = options;
+  if (isPlainObject(options)) {
+    $global.mixin = options;
+  } else {
+    console.error(
+      'Mixin global api supports plain object only\n\n' +
+      'e.g: \n\n' +
+      'wepy.mixin({\n' +
+      '  created () {\n' +
+      '    console.log(\'global mixin created\')\n' +
+      '  }\n' +
+      '})'
+    );
+  }
 }
 
 var wepy = Base;

--- a/packages/core/weapp/apis/index.js
+++ b/packages/core/weapp/apis/index.js
@@ -1,1 +1,2 @@
 export * from './use';
+export * from './mixin';

--- a/packages/core/weapp/apis/mixin.js
+++ b/packages/core/weapp/apis/mixin.js
@@ -1,5 +1,18 @@
 import $global from '../global';
+import { isPlainObject } from '../util/index';
 
 export function mixin (options = {}) {
-  $global.mixin = options;
+  if (isPlainObject(options)) {
+    $global.mixin = options;
+  } else {
+    console.error(
+      'Mixin global api supports plain object only\n\n' +
+      'e.g: \n\n' +
+      'wepy.mixin({\n' +
+      '  created () {\n' +
+      '    console.log(\'global mixin created\')\n' +
+      '  }\n' +
+      '})'
+    )
+  }
 }

--- a/packages/core/weapp/apis/mixin.js
+++ b/packages/core/weapp/apis/mixin.js
@@ -1,0 +1,5 @@
+import $global from '../global';
+
+export function mixin (options = {}) {
+  $global.mixin = options;
+}

--- a/packages/core/weapp/init/mixins.js
+++ b/packages/core/weapp/init/mixins.js
@@ -49,7 +49,7 @@ export function patchMixins (output, option, mixins) {
 
   if (!globalMixinPatched) {
     const globalMixin = $global.mixin || {};
-    mixins = [].concat(mixins).concat(globalMixin);
+    mixins = [globalMixin].concat(mixins);
     globalMixinPatched = true;
   }
 

--- a/packages/core/weapp/init/mixins.js
+++ b/packages/core/weapp/init/mixins.js
@@ -3,6 +3,9 @@ import { WEAPP_LIFECYCLE } from '../../shared/index';
 import { patchProps } from './props';
 import { patchData } from './data';
 import { config } from '../config';
+import $global from '../global';
+
+let globalMixinPatched = false;
 
 const defaultStrat = (parentVal, childVal) => childVal ? childVal : parentVal;
 let strats = null;
@@ -42,6 +45,12 @@ function initStrats () {
 export function patchMixins (output, option, mixins) {
   if (!mixins) {
     return;
+  }
+
+  if (!globalMixinPatched) {
+    const globalMixin = $global.mixin || {};
+    mixins = [].concat(mixins).concat(globalMixin);
+    globalMixinPatched = true;
   }
 
   if (isArr(mixins)) {

--- a/packages/core/weapp/wepy.js
+++ b/packages/core/weapp/wepy.js
@@ -3,7 +3,7 @@ import page from './page';
 import app from './app';
 import component from './component';
 import $global from './global';
-import { use } from './apis/index';
+import { use, mixin } from './apis/index';
 
 
 let wepy = Base;
@@ -15,7 +15,8 @@ Object.assign(wepy, {
   global: $global,
 
   // global apis
-  use
+  use,
+  mixin
 });
 
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

添加了全局 ```mixin```

e.g ：
``` javascript
wepy.mixin({
  created () {
    console.log('global mixin created')
  }
})
```