### PR TITLE
fix(core): fixed data patch

### DIFF
--- a/packages/core/dist/wepy.js
+++ b/packages/core/dist/wepy.js
@@ -956,7 +956,8 @@ function patchData (output, data, vm) {
  * init data
  */
 function initData (vm, data, output) {
-  vm._data = data || {};
+  var _data = data || {};
+  vm._data = _data;
   Object.keys(_data).forEach(function (key) {
     proxy(vm, '_data', key);
   });

--- a/packages/core/weapp/component.js
+++ b/packages/core/weapp/component.js
@@ -15,8 +15,6 @@ function component (option, rel) {
 
   patchMethods(compConfig, option.methods, true);
 
-  patchData(compConfig, option.data, true);
-
   patchLifecycle(compConfig, option, rel, true);
 
   return Component(compConfig);

--- a/packages/core/weapp/init/data.js
+++ b/packages/core/weapp/init/data.js
@@ -41,7 +41,8 @@ export function patchData (output, data, vm) {
  * init data
  */
 export function initData (vm, data, output) {
-  vm._data = data || {};
+  let _data = data || {};
+  vm._data = _data;
   Object.keys(_data).forEach(key => {
     proxy(vm, '_data', key);
   });

--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -8,7 +8,7 @@ import $global from './../global';
 import { initProps } from './props';
 import { initWatch } from './watch';
 import { initRender } from './render';
-import { initData } from './data';
+import { patchData, initData } from './data';
 import { initComputed } from './computed';
 import { initMethods } from './methods';
 import { initEvents } from './events';
@@ -72,10 +72,12 @@ export function patchComponentLifecycle (compConfig, options) {
 };
 
 export function patchLifecycle (output, options, rel, isComponent) {
-
   const initClass = isComponent ? WepyComponent : WepyPage;
+  let vm = new initClass();
+
+  patchData(output, options.data, vm, isComponent);
+
   const initLifecycle = function (...args) {
-    let vm = new initClass();
 
     vm.$dirty = new Dirty('path');
     vm.$children = [];
@@ -132,7 +134,6 @@ export function patchLifecycle (output, options, rel, isComponent) {
     };
   } else {
     output.attached = function (...args) { // Page attached
-      let vm = this.$wepy;
       let app = vm.$app;
       let pages = getCurrentPages();
       let currentPage = pages[pages.length - 1];

--- a/packages/core/weapp/page.js
+++ b/packages/core/weapp/page.js
@@ -1,4 +1,4 @@
-import { patchMixins, patchData, patchMethods, patchLifecycle, patchProps } from './init/index';
+import { patchMixins, patchMethods, patchLifecycle, patchProps } from './init/index';
 
 function page (option = {}, rel) {
 
@@ -16,8 +16,6 @@ function page (option = {}, rel) {
   }
 
   patchMethods(pageConfig, option.methods);
-
-  patchData(pageConfig, option.data);
 
   patchLifecycle(pageConfig, option, rel);
 


### PR DESCRIPTION
##### Checklist

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

##### Description
当```data```为 ```Function```时，经 patchData 处理后，```output.data``` 仍然是 ```Function```，这个在数据初始化的时候会带来问题，因为小程序构造器中，```data```不支持 ```Function```形式。现针对此情况做了相应处理。

e.g: 

```vue
<template>
  <div>{{foo}}</div>
</template>

<script>
import wepy from '@wepy/core'

wepy.page({
  data () {
    return {
      foo: 'bar'
    }
  }
})
</script>
```
