### PR TITLE
fix(cli): Fix the wrong path when usingComponents and require in windows environment

### DIFF
--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -208,7 +208,6 @@ class Compile extends Hook {
         if (!comps) {
           return null;
         }
-        debugger
         this.hookSeq('build-components', comps);
         this.hookUnique('output-components', comps);
 
@@ -348,9 +347,6 @@ class Compile extends Hook {
     };
 
     for (let k in outputMap) {
-      if (k === 'config') {
-        debugger
-      }
       if (sfc[k] && sfc[k].outputCode) {
         let filename = item.outputFile + '.' + outputMap[k];
         logger.silly('output', 'write file: ' + filename);

--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -11,9 +11,9 @@ const fs = require('fs-extra');
 const path = require('path');
 const chokidar = require('chokidar');
 const ResolverFactory = require('enhanced-resolve').ResolverFactory;
-const node = require("enhanced-resolve/lib/node");
-const NodeJsInputFileSystem = require("enhanced-resolve/lib/NodeJsInputFileSystem");
-const CachedInputFileSystem = require("enhanced-resolve/lib/CachedInputFileSystem");
+const node = require('enhanced-resolve/lib/node');
+const NodeJsInputFileSystem = require('enhanced-resolve/lib/NodeJsInputFileSystem');
+const CachedInputFileSystem = require('enhanced-resolve/lib/CachedInputFileSystem');
 const parseOptions = require('./parseOptions');
 const moduleSet = require('./moduleSet');
 const loader = require('./loader');
@@ -21,7 +21,7 @@ const logger = require('./util/logger');
 const VENDOR_DIR = require('./util/const').VENDOR_DIR;
 const Hook = require('./hook');
 const tag = require('./tag');
-const walk = require("acorn/dist/walk");
+const walk = require('acorn/dist/walk');
 
 const initCompiler = require('./init/compiler');
 const initParser = require('./init/parser');
@@ -208,7 +208,7 @@ class Compile extends Hook {
         if (!comps) {
           return null;
         }
-
+        debugger
         this.hookSeq('build-components', comps);
         this.hookUnique('output-components', comps);
 
@@ -348,6 +348,9 @@ class Compile extends Hook {
     };
 
     for (let k in outputMap) {
+      if (k === 'config') {
+        debugger
+      }
       if (sfc[k] && sfc[k].outputCode) {
         let filename = item.outputFile + '.' + outputMap[k];
         logger.silly('output', 'write file: ' + filename);

--- a/packages/cli/core/plugins/build/components.js
+++ b/packages/cli/core/plugins/build/components.js
@@ -16,6 +16,16 @@ exports = module.exports = function () {
       config.parsed.output.component = true;
       const {usingComponents, ...other} = config.parsed.output
       let newUsingComponents = {}
+      /**
+       * 在windows环境中解析的usingComponent格式为
+       * usingComponent: {
+       *  test: '..\..\test'
+       * }
+       * 需要转换成
+       * usingComponent: {
+       *  test: '../../test'
+       * }
+       */
       for (let i in usingComponents) {
         newUsingComponents[i] = usingComponents[i].replace(/\\/g, '/')
       }

--- a/packages/cli/core/plugins/build/components.js
+++ b/packages/cli/core/plugins/build/components.js
@@ -13,10 +13,17 @@ exports = module.exports = function () {
       styles.forEach(v => {
         styleCode += v.parsed.code + '\n';
       });
-
       config.parsed.output.component = true;
-      config.outputCode = JSON.stringify(config.parsed.output, null, 4);
-
+      const {usingComponents, ...other} = config.parsed.output
+      let newUsingComponents = {}
+      for (let i in usingComponents) {
+        newUsingComponents[i] = usingComponents[i].replace(/\\/g, '/')
+      }
+      let output = {
+        ...other,
+        usingComponents: newUsingComponents
+      }
+      config.outputCode = JSON.stringify(output, null, 4);
       this.hookSeq('script-dep-fix', script.parsed);
       if (!script.empty && !comp.wxComponent) {
         this.hookSeq('script-injection', script.parsed, template.parsed.rel);

--- a/packages/cli/core/plugins/scriptDepFix.js
+++ b/packages/cli/core/plugins/scriptDepFix.js
@@ -13,7 +13,7 @@ exports = module.exports = function () {
       } else {
         if (typeof depMod === 'object' && !depMod.npm && !depMod.component) {
           // dep is not a npm package, and it's not a component
-          let relativePath = path.relative(path.dirname(parsed.file), depMod.file);
+          let relativePath = path.relative(path.dirname(parsed.file), depMod.file).replace(/\\/g, '/');
           replaceMent = `require('${relativePath}')`;
         } else {
           if (typeof moduleId === 'number') {
@@ -24,11 +24,12 @@ exports = module.exports = function () {
             } else {
               relativePath = path.relative(path.dirname(parsed.file), npmfile);
             }
+            relativePath = relativePath.replace(/\\/g, '/')
             replaceMent = `require('${relativePath}')(${moduleId})`;
           } else if (depMod && depMod.component) {
             let relativePath = path.relative(path.dirname(parsed.file), depMod.file);
             let reg = new RegExp('\\' + this.options.wpyExt + '$', 'i');
-            relativePath = relativePath.replace(reg, '.js');
+            relativePath = relativePath.replace(reg, '.js').replace(/\\/g, '/');
             replaceMent = `require('${relativePath}')`;
           } else if (depMod === false) {
             replaceMent = '{}';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

修复在windows环境中usingComponents及require时的错误路径
- require
![1](https://user-images.githubusercontent.com/3926479/46674793-a0412600-cc0f-11e8-80db-3a4293e997d0.png)
修复后
![2](https://user-images.githubusercontent.com/3926479/46674819-ab945180-cc0f-11e8-9a07-8168cda392e5.png)

- usingComponents
![3](https://user-images.githubusercontent.com/3926479/46674873-cd8dd400-cc0f-11e8-8621-f965096eb5e7.png)
修复后
![4](https://user-images.githubusercontent.com/3926479/46674882-d383b500-cc0f-11e8-8e3b-1d7fde6d831b.png)


