### PR TITLE
增加微信原生模板标签template的支持

### DIFF
--- a/packages/cli/core/tag.js
+++ b/packages/cli/core/tag.js
@@ -63,7 +63,9 @@ const HTML2WXML_MAP = {
   'track': 'video',
   'a': 'navigator',
   'span': 'label',
-  'contact-button': 'contact-button'
+  'contact-button': 'contact-button',
+  // support template [template](https://developers.weixin.qq.com/miniprogram/dev/framework/view/wxml/template.html)
+  'wx-template': 'template'
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

> WXML提供[模板（template）](https://developers.weixin.qq.com/miniprogram/dev/framework/view/wxml/template.html)，可以在模板中定义代码片段，然后在不同的地方调用

wepy文件中写入原生模板标签`template`会被转换成`view`标签，现增加`wx-template`标签，可转换成原生的`template`

```html
<template>test</template>
<wx-template name="test">
  <div>test</div>
</wx-template>
<wx-template is="test"></wx-template>
```
将转换成
```html
<view>test</view>
<template name="test">
  <view>test</view>
</template>
<template is="test"></template>
```