### PR TITLE
feat(cli): support subpackages / subPackges

### DIFF
--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -197,8 +197,8 @@ class Compile extends Hook {
         return path.resolve(app.file, '..', v + this.options.wpyExt);
       });
 
-      if (appConfig.subPackages) {
-        appConfig.subPackages.forEach(sub => {
+      if (appConfig.subPackages || appConfig.subpackages) {
+        (appConfig.subpackages || appConfig.subPackages).forEach(sub => {
            sub.pages.forEach(v => {
             pages.push(path.resolve(app.file, '../'+sub.root || '', v + this.options.wpyExt));
           });


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

### Example
compatible subpackges or subPackges in app config

```app.wpy```

```vue
<config>
{
    subPackages: [
       {
          root: ''",
          name: "",
          pages: []
       }
    ]
}
</config>
```
or
```vue
<config>
{
    subpackages: [
       {
          root: ''",
          name: "",
          pages: []
       }
    ]
}
</config>
```

