### PR TITLE
fix: 修复组件中使用wxs事件

### DIFF
--- a/packages/wepy-cli/src/compile-template.js
+++ b/packages/wepy-cli/src/compile-template.js
@@ -311,7 +311,11 @@ export default {
                             node.setAttribute(paramAttr, p);
                         });
                     }
-                    if (prefix)
+
+                    let match = attr.value.match(/^\{\{\s*(\w+)(\.|\[).*\}\}$/);
+                    let useWxs = match && match[1] && ignores[match[1]];
+                    
+                    if (prefix && !useWxs)
                         attr.value = `${PREFIX}${prefix}${JOIN}` + attr.value;
                 }
                 if (attr.name === 'a:for-items' && config.output === 'ant') {


### PR DESCRIPTION
组件中使用wxs事件，会被当作组件变量编译成$parent$wxs这种形式，实际上这里不应该被处理

- 修复组件中使用wxs事件不生效的问题

Issue #2068
Close #2068

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
