### PR TITLE
refactor(core): WepyComponent 的 $nextTick 属性定义改为 es6 写法 和 fix(core): 注册 App 缺少 patchMixins

### DIFF
--- a/packages/core/weapp/native/app.js
+++ b/packages/core/weapp/native/app.js
@@ -1,8 +1,9 @@
-import { patchAppLifecycle } from '../init/index';
+import { patchMixins, patchAppLifecycle } from '../init/index';
 
 export function app (option, rel) {
   let appConfig = {};
 
+  patchMixins(appConfig, option, option.mixins);
   patchAppLifecycle(appConfig, option, rel);
 
   return App(appConfig);


### PR DESCRIPTION
1. 类的定义统一采用 es6 的写法
2. 注册 App 缺少 patchMixins