### PR TITLE
fix(core): patchAppLifecycle 和 patchLifecycle

### DIFF
--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -183,7 +183,7 @@ export function patchLifecycle (output, options, rel, isComponent) {
 
     lifecycle.forEach(k => {
       if (!output[k] && options[k] && (isFunc(options[k]) || isArr(options[k]))) {
-        output[k] = function (...args) {
+        output.methods[k] = function (...args) {
           return callUserMethod(this.$wepy, this.$wepy.$options, k, args);
         }
       }

--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -82,7 +82,7 @@ export function patchAppLifecycle (appConfig, options, rel = {}) {
     // it's not defined aready && user defined it && it's an array or function
     if (!appConfig[k] && options[k] && (isFunc(options[k]) || isArr(options[k]))) {
       appConfig[k] = function (...args) {
-        return callUserMethod(vm, vm.$options, k, args);
+        return callUserMethod(app, app.$options, k, args);
       };
     }
   });


### PR DESCRIPTION
1. fix(core): 调用 app 生命周期传参错误
2. fix(core): 页面生命周期定义位置错误
使用 Component 构造器构造页面，页面的生命周期方法（即 on 开头的方法），应写在 methods 定义段中
