### PR TITLE
refactor(core): 优化 observerFn 的实现

### DIFF
--- a/packages/core/weapp/init/props.js
+++ b/packages/core/weapp/init/props.js
@@ -8,34 +8,16 @@ const AllowedTypes = [ String, Number, Boolean, Object, Array, null ];
 const observerFn = function (output, props, prop) {
   return function (newVal, oldVal, changedPaths) {
     let vm = this.$wepy;
-    if (vm._fromSelf) {
-      vm._fromSelf = false;
-      return;
+
+    // changedPaths 长度大于 1，说明是由内部赋值改变的 prop
+    if (changedPaths.length > 1) {
+      return
     }
-    let _props;
     let _data = newVal;
-    let key = changedPaths[0];
     if (typeof _data === 'function') {
       _data = _data.call(vm);
     }
-
-    _props = vm._props || {};
-    // _props[key] = _data;
-    vm._props = _props;
-    Object.keys(_props).forEach(key => {
-      proxy(vm, '_props', key);
-    });
-
-    observe({
-      vm: vm,
-      key: '',
-      value: _props,
-      root: true
-    });
-
-    initRender(vm, Object.keys(_props));
-
-    vm[key] = _data;
+    vm[changedPaths[0]] = _data;
   };
 };
 /*


### PR DESCRIPTION
#2210 如此 issue 讨论的问题
不过还有两个问题没解决：
1. 当 changePaths 长度为 1 时，没法区分是组件内赋值还是父组件 WXML 数据绑定
2. 这是个 bug，跟本次 PR 无关。当有一个prop，父组件赋值为 a，然后组件赋值为 b，然后父组件再赋值为相同的 a，不会触发 setData，因为父组件内容没有变，set 里直接返回了，没有触发 notify。
解决方案：多写一次赋值，先赋值为其他值，再赋值回来（this.prop = x; this.prop = a）；或者修改 set 去掉 set 里的比较，后者得考虑会不会产生其他影响。
![image](https://user-images.githubusercontent.com/12985781/61182159-14f33600-a662-11e9-84f4-0592605d0f01.png)
