### PR TITLE
refactor(core): $dirty 的 path 考虑复杂相互引用的情况

### DIFF
--- a/packages/core/weapp/observer/array.js
+++ b/packages/core/weapp/observer/array.js
@@ -39,17 +39,8 @@ methodsToPatch.forEach(function (method) {
       }
     }
 
-    let isInserted = false;
-    switch (method) {
-      case 'push':
-      case 'unshift':
-        isInserted = true;
-        break;
-      case 'splice':
-        isInserted = true;
-        break;
-    }
-    if (isInserted) ob.observeArray(ob.key, ob.value);
+    // 这里和 vue 不一样，所有变异方法都需要更新 path
+    ob.observeArray(ob.key, ob.value)
     // notify change
     ob.dep.notify();
     return result;

--- a/packages/core/weapp/observer/observerPath.js
+++ b/packages/core/weapp/observer/observerPath.js
@@ -1,0 +1,146 @@
+/**
+ * @desc ObserverPath 类
+ * Observer 所在位置对应在整棵 data tree 的路径集合
+ * @createDate 2019-07-21
+ */
+
+import {hasOwn, isNum, isObject} from '../util/index'
+
+export default class ObserverPath {
+  constructor (key, parent, observer) {
+    this.observer = observer;
+    this.pathMap = this.getPathMap(key, parent && parent.__ob__.observerPath);
+  }
+
+  /**
+   * 将要更新的数据放入 dirty
+   * 其中 key 为空串时，表示其路径是自身，否则是其子节点
+   */
+  setDirty (key, value, dirty) {
+    const pathMap = key ? this.getPathMap(key, this) : this.pathMap;
+    const keys = Object.keys(pathMap);
+    for (let i = 0; i < keys.length; i++) {
+      const {root, path} = pathMap[keys[i]];
+      if (this.hasPath(path, this.observer.vm)) {
+        dirty.push(root, path, value);
+      } else {
+        delete pathMap[keys[i]];
+      }
+    }
+  }
+
+  /**
+   * 更新 __ob__ 的 path
+   */
+  traverseUpdatePath (key, value, parent) {
+    // 得到此 value 挂载到 parent 的 pathMap
+    const pathMap = this.getPathMap(key, parent && parent.__ob__.observerPath);
+    const keys = Object.keys(pathMap);
+
+    // 遍历 pathMap
+    for (let i = 0; i < keys.length; i++) {
+      const {root, path} = pathMap[keys[i]];
+
+      // 判断 path 是否存在，如果不存在则新增一条 path
+      if (!(path in this.pathMap)) {
+        this.pathMap[path] = {key, root, path};
+
+        // 深度遍历更新路径
+        let keys;
+        if (Array.isArray(value)) {
+          keys = Array.from(Array(value.length), (val, index) => index);
+        } else {
+          keys = Object.keys(value);
+        }
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          if (isObject(value[key]) && hasOwn(value[key], '__ob__')) {
+            value[key].__ob__.observerPath.traverseUpdatePath(key, value[key], value, this.observer.vm);
+          }
+        }
+
+        // 清除不存在的路径
+        keys = Object.keys(this.pathMap);
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          if (!this.propPathEq(this.pathMap[key].path, value, this.observer.vm)) {
+            delete this.pathMap[key];
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * 得到父路径集合和子节点组合后的路径集合
+   */
+  getPathMap (key, parentObserverPath) {
+    if (parentObserverPath) {
+      const parentPathMap = parentObserverPath.pathMap;
+      const setPath = isNum(key) ? path => `${path}[${key}]` : path => `${path}.${key}`;
+      let pathMap = {};
+      const keys = Object.keys(parentPathMap)
+      for (let i = 0; i < keys.length; i++) {
+        if (parentPathMap[keys[i]].path) {
+          const path = setPath(parentPathMap[keys[i]].path);
+          let root = '';
+          for (let j = 0; (j < path.length) && (path[j] !== '.' && path[j] !== '['); j++) {
+            root += path[j];
+          }
+          pathMap[path] = {key, root, path};
+        } else {
+          pathMap[key] = {key, root: key, path: key}
+        }
+      }
+      return pathMap;
+    }
+    return {[key]: {key, root: key, path: key}};
+  }
+
+  /**
+   * 比较 obj 指定 path 上的值与 value 是否相等
+   */
+  propPathEq (path, value, obj) {
+    let objValue = obj;
+    let key = '';
+    let i = 0;
+    while (i < path.length) {
+      if (path[i] !== '.' && path[i] !== '[' && path[i] !== ']') {
+        key += path[i];
+      } else if (key.length !== 0) {
+        objValue = objValue[key];
+        key = '';
+        if (!isObject(objValue)) {
+          return false;
+        }
+      }
+      i++;
+    }
+    if (key.length !== 0) {
+      objValue = objValue[key];
+    }
+    return value === objValue;
+  }
+
+  /**
+   * obj 上是否存在此 path
+   */
+  hasPath (path, obj) {
+    let value = obj;
+    let key = '';
+    let i = 0;
+    while (i < path.length) {
+      if (path[i] !== '.' && path[i] !== '[' && path[i] !== ']') {
+        key += path[i];
+      } else if (key.length !== 0) {
+        value = value[key];
+        key = '';
+        if (!isObject(value)) {
+          return false;
+        }
+      }
+      i++;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
由于把 setData 的操作透明化了，所以在实际开发中就可能会出现复杂引用的情况。
比如：data 有两个属性 a 和 b。a 赋值给了对象 c，然后 b 也赋值给了对象 c。那么对 c 里某个属性做赋值操作，在放入 $dirty 时，实际应该是会有两组 path，'a.x' 和 'b.x'，而目前只会放入一组 'a.x'。这算比较简单的情况，更复杂可能出现很多这种嵌套的菱形关系。
#2256 是这个问题的一个数组情况特例，