### PR TITLE
fix(core): 不恰当的隐式转换和 setData 调用可能乱序

### DIFF
--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -146,6 +146,9 @@ export function patchLifecycle (output, options, rel, isComponent) {
       let vm = this.$wepy;
       let parent = this.triggerEvent('_init', vm);
 
+      // created 不能调用 setData，如果有 dirty 在此更新
+      vm.$forceUpdate()
+
       initEvents(vm);
 
       Object.keys(outProps).forEach(k => vm[k] = acceptProps[k]);
@@ -160,6 +163,10 @@ export function patchLifecycle (output, options, rel, isComponent) {
       let currentPage = pages[pages.length - 1];
       let path = currentPage.__route__;
       let webViewId = currentPage.__wxWebviewId__;
+
+      // created 不能调用 setData，如果有 dirty 在此更新
+      vm.$forceUpdate()
+
       if (app.$route.path !== path) {
         app.$route.path = path;
         app.$route.webViewId = webViewId;

--- a/packages/core/weapp/init/props.js
+++ b/packages/core/weapp/init/props.js
@@ -72,7 +72,7 @@ export function patchProps (output, props) {
       }
 
       // props.default
-      if (prop.default) {
+      if (!isUndef(prop.default)) {
         if (isFunc(prop.default)) {
           newProp.value = prop.default.call(output);
         } else {

--- a/packages/core/weapp/init/render.js
+++ b/packages/core/weapp/init/render.js
@@ -13,13 +13,13 @@ export function resetDirty (vm) {
 
 export function initRender (vm, keys) {
   vm._init = false;
-  let cacheData = null
+  let dirtyFromAttach = null
   return new Watcher(vm, function () {
     if (!vm._init) {
       keys.forEach(key => clone(vm[key]));
     }
 
-    if (vm.$dirty.length() || cacheData) {
+    if (vm.$dirty.length() || dirtyFromAttach) {
       let keys = vm.$dirty.get('key');
       let dirty = vm.$dirty.pop();
 
@@ -31,15 +31,15 @@ export function initRender (vm, keys) {
       }
 
       // vm._fromSelf = true;
-      if (dirty || cacheData) {
+      if (dirty || dirtyFromAttach) {
         // init render is in lifecycle, setData in lifecycle will not work, so cacheData is needed.
         if (!vm._init) {
-          if (cacheData === null) {
-            cacheData = {}
+          if (dirtyFromAttach === null) {
+            dirtyFromAttach = {};
           }
-          Object.assign(cacheData, dirty)
-        } else if (cacheData) {  // setData in attached
-          vm.$wx.setData(Object.assign(cacheData, dirty || {}), renderFlushCallbacks);
+          Object.assign(dirtyFromAttach, dirty)
+        } else if (dirtyFromAttach) {  // setData in attached
+          vm.$wx.setData(Object.assign(dirtyFromAttach, dirty || {}), renderFlushCallbacks);
           cacheData = null
         } else {
           vm.$wx.setData(dirty, renderFlushCallbacks);


### PR DESCRIPTION
1. fix(core): 修复 if (prop.default) 会发生隐身转换，导致部分默认值设置无效
2. fix(core): 修复 vm._init 为 false 时，setData 调用可能发生乱序的问题。因为下一个 setData 可能会比 nextTick setData 先执行 