### PR TITLE
refactor(core): 优化 wxs 解析逻辑 与 applyCompiler 中关于 involved 的修改逻辑

### DIFF
--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -6,7 +6,6 @@
  * http://opensource.org/licenses/MIT
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-const sfcCompiler = require('vue-template-compiler');
 const fs = require('fs-extra');
 const path = require('path');
 const chokidar = require('chokidar');
@@ -169,7 +168,6 @@ class Compile extends Hook {
   }
 
   start () {
-
     if (this.running) {
       return;
     }
@@ -328,8 +326,6 @@ class Compile extends Hook {
   }
 
   applyCompiler (node, ctx) {
-    let compiler;
-
     ctx.id = this.assets.add(ctx.file);
 
     if (node.lang) {
@@ -339,7 +335,10 @@ class Compile extends Hook {
         throw `Missing plugins ${hookKey}`;
       }
 
-      this.involved[ctx.file] = 1;
+      // If node has src, then do not change involved
+      if (!node.src) {
+        this.involved[ctx.file] = 1;
+      }
 
       let task;
 
@@ -427,9 +426,6 @@ class Compile extends Hook {
     }
   }
 }
-
-
-
 
 exports = module.exports = (program) => {
   let opt = parseOptions.convert(program);

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wepy/cli",
-	"version": "2.0.0-alpha.15",
+	"version": "2.0.0-alpha.16",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
1. 原 wxs 解析的时候会有个问题是：如果 wxs 标签块是内联代码，解析后会导致 compiled 里面此 wpy 文件的 hash 会去掉，这样缓存就失效了。优化改为如果 wxs 是内联代码而整个文件的 hash 又没有变化时不去 compile；如果 wxs 是外部文件则保持原来的逻辑。

2. `applyCompiler()`  中原来直接更改了 involved[ctx.file] 的值。但如果是编译 wxs 外部文件的代码时， 此时 ctx.file 是外部文件的路径，也会被直接改掉。而 involved[ctx.file] 的值在这种情况下应该还是要记录对应 wpy 文件的路径，这样在 watch 中对应的代码才会执行，清除掉 wpy 文件的 hash。所以这里做了判断，如果 node 有 src，则不清除。