### PR TITLE
refactor(cli): 优化 watch 时的编译效率和一些潜在问题

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/cli/core/tag.js
+++ b/packages/cli/core/tag.js
@@ -1,3 +1,5 @@
+const { isArr } = require('./util/tools');
+
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 const HTML_TAGS = [
 // Main root
@@ -75,8 +77,10 @@ const HTML2WXML_MAP = {
  * @return {Array} new tag list Array
  */
 const combineTag = function (original, additional) {
-  if (typeof additional === 'string' || Array.isArray(additional)) {
+  if (isArr(additional)) {
     return original.concat(additional);
+  } else if (typeof additional === 'string') {
+    return original.concat(additional.split(','));
   } else if (typeof additional !== 'object') {
     return [].concat(original);
   }

--- a/packages/cli/test/core/tag.test.js
+++ b/packages/cli/test/core/tag.test.js
@@ -1,0 +1,36 @@
+const expect = require('chai').expect;
+const tag = require('../../core/tag');
+
+describe('tag', function() {
+  it('should combineTagMap', function() {
+    const additional = {
+      'test-tag-1': 'to-test-tag-1',
+      'test-tag-2': 'to-test-tag-2'
+    };
+    const ret = tag.combineTagMap(tag.HTML2WXML_MAP, additional);
+
+    expect(ret).to.include(tag.HTML2WXML_MAP);
+    expect(ret).to.include(additional);
+  });
+
+  it('should combineTag', function() {
+    let additional = 'add-test-tag-1';
+    let ret = tag.combineTag(tag.HTML_TAGS, additional);
+    expect(ret).to.include.members(tag.HTML_TAGS);
+    expect(ret).to.include(additional);
+
+    additional = 'add-test-tag-1,add-test-tag-2';
+    ret = tag.combineTag(tag.HTML_TAGS, additional);
+    expect(ret).to.include.members(tag.HTML_TAGS);
+    expect(ret).to.include.members(additional.split(','));
+
+    additional = ['add-test-tag-1', 'add-test-tag-2'];
+    ret = tag.combineTag(tag.HTML_TAGS, additional);
+    expect(ret).to.include.members(tag.HTML_TAGS);
+    expect(ret).to.include.members(additional);
+
+    additional = 123;
+    ret = tag.combineTag(tag.HTML_TAGS, additional);
+    expect(ret).to.eql(tag.HTML_TAGS);
+  });
+});


### PR DESCRIPTION
原来 watch 在重新编译时会每次都从入口开始，现在优化为如果更改的文件是 wpyExt 则只编译改变的文件。拿我们实际重构的项目测试速度提升明显，后面将继续优化其他类型的引用文件。
我们的项目就是 #2263 楼主提到的。