### PR TITLE
refactor(cli): 优化 watch 时利用 hook 分发给对应的 compiler 处理

### DIFF
--- a/packages/compiler-less/index.js
+++ b/packages/compiler-less/index.js
@@ -31,5 +31,10 @@ exports = module.exports = function (options) {
         return node;
       });
     });
+
+    this.register('wepy-watch-file-changed-less', function (buildTask) {
+      buildTask.files = this.fileDep.getSources(buildTask.changed);
+      return buildTask;
+    });
   }
 };


### PR DESCRIPTION
重构了 watch() 时的执行逻辑，利用 hook 分发给对应的 compiler 处理。