### PR TITLE
refactor(cli): 优化 FileDep 并加入单元测试

### DIFF
--- a/packages/cli/core/fileDep.js
+++ b/packages/cli/core/fileDep.js
@@ -4,25 +4,31 @@ class FileDep {
     this._depedMap = {};
   }
 
-  update(source, deps = []) {
-    this.cleanupDeps(source, deps);
-    this._depMap[source] = deps;
+  cleanDeps(source) {
+    const deps = this._depMap[source] || [];
     deps.forEach(dep => {
-      if (this._depedMap[dep] == null) {
-        this._depedMap[dep] = [];
-      }
-      if (!this._depedMap[dep].includes(source)) {
-        this._depedMap[dep].push(source);
+      const depeds = this._depedMap[dep] || [];
+      if (depeds.length > 0) {
+        this._depedMap[dep] = depeds.filter(deped => deped !== source);
+        if (this._depedMap[dep].length === 0) {
+          delete this._depedMap[dep];
+        }
       }
     });
+    delete this._depMap[source];
   }
 
-  cleanupDeps(source, newDeps = []) {
-    const oldDeps = this._depMap[source] || [];
-    oldDeps.forEach(oldDep => {
-      if (!newDeps.includes(oldDep)) {
-        const depeds = this._depedMap[oldDep] || [];
-        this._depedMap[oldDep] = depeds.filter(deped => deped !== source);
+  addDeps(source, deps = []) {
+    if (!this._depMap[source]) {
+      this._depMap[source] = [];
+    }
+    deps.forEach(dep => {
+      if (!this._depMap[source].includes(dep)) {
+        this._depMap[source].push(dep);
+        if (!this._depedMap[dep]) {
+          this._depedMap[dep] = [];
+        }
+        this._depedMap[dep].push(source);
       }
     });
   }

--- a/packages/cli/core/plugins/parser/wpy.js
+++ b/packages/cli/core/plugins/parser/wpy.js
@@ -43,6 +43,7 @@ exports = module.exports = function () {
       this.compiled[file] = context;
       context.useCache = false;
       context.hash = fileHash;
+      this.fileDep.cleanDeps(file);
 
       context.sfc = sfcCompiler.parseComponent(fileContent, { pad: 'space' });
 

--- a/packages/cli/test/core/fileDep.test.js
+++ b/packages/cli/test/core/fileDep.test.js
@@ -1,0 +1,35 @@
+const expect = require('chai').expect;
+const FileDep = require('../../core/fileDep');
+
+describe('FileDep', function () {
+  it('should addDeps, getDeps and getSources', function () {
+    const fileDep = new FileDep();
+
+    fileDep.addDeps('a.wpy', ['b.js', 'c.js']);
+    expect(fileDep.getDeps('a.wpy')).to.eql(['b.js', 'c.js']);
+    expect(fileDep.getSources('c.js')).to.eql(['a.wpy']);
+
+    fileDep.addDeps('b.wpy', ['c.js', 'd.js']);
+    expect(fileDep.getDeps('b.wpy')).to.eql(['c.js', 'd.js']);
+    expect(fileDep.getSources('c.js')).to.eql(['a.wpy', 'b.wpy']);
+  });
+
+  it('should cleanDeps', function () {
+    const fileDep = new FileDep();
+
+    fileDep.addDeps('a.wpy', ['b.js', 'c.js']);
+    fileDep.cleanDeps('a.wpy');
+    expect(fileDep.getDeps('a.wpy')).to.eql([]);
+    expect(fileDep.getSources('b.js')).to.eql([]);
+    expect(fileDep.getSources('c.js')).to.eql([]);
+
+    fileDep.addDeps('a.wpy', ['b.js', 'c.js']);
+    fileDep.addDeps('b.wpy', ['c.js', 'd.js']);
+    fileDep.cleanDeps('a.wpy');
+    expect(fileDep.getDeps('a.wpy')).to.eql([]);
+    expect(fileDep.getDeps('b.wpy')).to.eql(['c.js', 'd.js']);
+    expect(fileDep.getSources('b.js')).to.eql([]);
+    expect(fileDep.getSources('c.js')).to.eql(['b.wpy']);
+    expect(fileDep.getSources('d.js')).to.eql(['b.wpy']);
+  });
+});

--- a/packages/compiler-less/index.js
+++ b/packages/compiler-less/index.js
@@ -27,7 +27,7 @@ exports = module.exports = function (options) {
           code: rst.css,
           dep: rst.imports
         };
-        this.fileDep.update(file, node.compiled.dep);
+        this.fileDep.addDeps(file, node.compiled.dep);
         return node;
       });
     });

--- a/packages/compiler-less/test/index.test.js
+++ b/packages/compiler-less/test/index.test.js
@@ -12,7 +12,7 @@ class Hook {
   constructor () {
     // file will be involved for watch
     this.involved = {};
-    this.fileDep = { update () {} };
+    this.fileDep = { addDeps () {} };
   }
 
   register (key, fn) {


### PR DESCRIPTION
优化 FileDep，在 hash 改变时清除依赖，分发到 compile 或 parser 时收集依赖。
下一个 commit 会替换 `this.involved`。