### PR TITLE
refactor(cli): return unregister from Hook.register

### DIFF
--- a/packages/cli/core/hook.js
+++ b/packages/cli/core/hook.js
@@ -8,6 +8,22 @@ class Hook {
       this._hooks[key] = [];
     }
     this._hooks[key].push(fn);
+
+    const createUnregister = function (key, fn) {
+      return function () {
+        let fns = this._hooks[key];
+        if (fns && typeof fn === 'function') {
+          fns = fns.filter(f => f !== fn);
+          if (fns.length > 0) {
+            this._hooks[key] = fns;
+          } else {
+            delete this._hooks[key];
+          }
+        }
+      };
+    };
+
+    return createUnregister(key, fn).bind(this);
   }
 
   hasHook (key) {
@@ -93,18 +109,6 @@ class Hook {
       (typeof fn === 'function') && (fn.apply(this, args));
     });
     return (args.length <= 1 ? args[0] : args);
-  }
-
-  unregister (key, fn) {
-    let fns = this._hooks[key];
-    if (fns && typeof fn === 'function') {
-      fns = fns.filter(f => f !== fn);
-      if (fns.length > 0) {
-        this._hooks[key] = fns;
-      } else {
-        delete this._hooks[key];
-      }
-    }
   }
 
   unregisterAll (key) {

--- a/packages/cli/test/core/hook.test.js
+++ b/packages/cli/test/core/hook.test.js
@@ -20,11 +20,12 @@ describe('Hook', function () {
     const handler2 = function () {
     };
 
-    hook.register('process-test', handler1);
+    const unregisterHandler1 = hook.register('process-test', handler1);
     hook.register('process-test', handler2);
     expect(hook._hooks['process-test']).to.includes(handler1);
     expect(hook._hooks['process-test']).to.includes(handler2);
-    hook.unregister('process-test', handler1);
+
+    unregisterHandler1();
     expect(hook._hooks['process-test']).to.not.includes(handler1);
     expect(hook._hooks['process-test']).to.includes(handler2);
 


### PR DESCRIPTION
重构 unregister，使之从 register 中返回。使用方式如下：
```javascript
const hook = new Hook();
const unregister = hook.register('process-test', function() {
  // ...
});

// don't want to hook
unregister();
```