### PR TITLE
feat(cli): support nodejs api

### DIFF
--- a/packages/cli/bin/wepy-build.js
+++ b/packages/cli/bin/wepy-build.js
@@ -1,13 +1,11 @@
 const compile = require('../core/compile');
+const parseOptions = require('../core/parseOptions');
 
 exports = module.exports = (program) => {
+  const options = parseOptions.convert(program);
+  const compilation = compile(options);
 
-  let compilation = compile(program);
-
-  compilation.init().then((flag) => {
-    compilation.start();
-  }).catch(e => {
+  compilation.run().catch(e => {
     compilation.logger.error('init', e.message);
   });
-
 }

--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -476,7 +476,11 @@ class Compile extends Hook {
 }
 
 exports = module.exports = (program) => {
-  let opt = parseOptions.convert(program);
+  const opt = parseOptions.parse(program);
 
-  return new Compile(opt);
+  const compilation = new Compile(opt);
+
+  compilation.run = () => compilation.init().then(() => compilation.start());
+
+  return compilation;
 };

--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -114,6 +114,10 @@ class Compile extends Hook {
     return this;
   }
 
+  run () {
+    return this.init().then(() => this.start())
+  }
+
   init () {
     this.register('process-clear', type => {
       this.compiled = {};
@@ -479,8 +483,6 @@ exports = module.exports = (program) => {
   const opt = parseOptions.parse(program);
 
   const compilation = new Compile(opt);
-
-  compilation.run = () => compilation.init().then(() => compilation.start());
 
   return compilation;
 };

--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -115,7 +115,7 @@ class Compile extends Hook {
   }
 
   run () {
-    return this.init().then(() => this.start())
+    return this.init().then(() => this.start());
   }
 
   init () {

--- a/packages/cli/core/parseOptions.js
+++ b/packages/cli/core/parseOptions.js
@@ -11,6 +11,8 @@ const DEFAULT_OPTIONS = {
   'wpyExt': { type: String, default: '.wpy' },
   'eslint': { type: Boolean, default: true },
   'cliLogs': { type: Boolean, default: false },
+  'watch': { type: Boolean, default: false },
+  'noCache': { type: Boolean, default: false },
   'build.web': { type: Object },
   'build.web.htmlTemplate': { type: String },
   'build.web.htmlOutput': { type: String },
@@ -110,9 +112,6 @@ function convert (args) {
 
   let opt = require(DEFAULT_CONFIG);
   let argOpt = parse(args, DEFAULT_OPTIONS, true);
-
-  argOpt.watch = !!args.watch;
-  argOpt.noCache = !!args.noCache;
 
   return Object.assign({}, parse(opt), argOpt);
 }

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,0 +1,1 @@
+exports = module.exports = require('./core/compile.js');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wepy/cli",
   "version": "2.0.0-alpha.19",
-  "main": "bin/wepy.js",
+  "main": "index.js",
   "bin": {
     "wepy": "bin/wepy.js"
   },


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

nodejs api support

### Usage

```javascript
const compiler = require('@wepy/cli')

const compilation = compiler({
  entry: 'app',
  watch: true,
 // ... other options
})

compilation.run()
  .catch(e => {
     // error handler
  })
```
