### PR TITLE
fix(cli): fixed priority of "+" operator for bindStyle

### DIFF
--- a/packages/cli/core/plugins/template/attrs/bindStyle.js
+++ b/packages/cli/core/plugins/template/attrs/bindStyle.js
@@ -1,11 +1,15 @@
 const exprParser = require('../../../util/exprParser');
 
 exports = module.exports = function () {
-
-  this.register('template-parse-ast-attr-:style', function parseBindClass ({item, name, expr}) {
+  this.register('template-parse-ast-attr-:style', function parseBindStyle({ item, name, expr }) {
     let exprObj = exprParser.str2obj(expr);
     item.bindStyle = Object.keys(exprObj).map(name => {
       let exp = exprObj[name].replace(/\'/ig, '\\\'').replace(/\"/ig, '\\"');
+
+      // add brackets to fix priority of "+" operator.
+      if (/^\(.*\)$/.test(exp) === false) {
+        exp = `(${exp})`;
+      }
       name = name.replace(/\'/ig, '\\\'').replace(/\"/ig, '\\"');
       name = exprParser.hyphenate(name);
       return `'${name}:' + ${exp} + ';'`;

--- a/packages/cli/test/core/fixtures/template/assert/bindStyle.wxml
+++ b/packages/cli/test/core/fixtures/template/assert/bindStyle.wxml
@@ -1,0 +1,1 @@
+<view style=" {{ 'background:' + (current === idx ? activeColor : normalColor) + ';' }}"></view>

--- a/packages/cli/test/core/fixtures/template/original/bindStyle.html
+++ b/packages/cli/test/core/fixtures/template/original/bindStyle.html
@@ -1,0 +1,1 @@
+<div :style="{ 'background': current === idx ? activeColor : normalColor }"></div>

--- a/packages/cli/test/core/plugins/template/parse.test.js
+++ b/packages/cli/test/core/plugins/template/parse.test.js
@@ -9,8 +9,7 @@ const moduleSet = require(`${alias.core}/moduleSet`);
 const pt = require(`${alias.plugins}/template/parse`);
 
 
-
-function cached (fn) {
+function cached(fn) {
   var _cache = {};
   return function (key) {
     if (!_cache[key]) {
@@ -35,7 +34,8 @@ const spec = {
     { file: 'v-if' },
     { file: 'v-for' },
     { file: 'v-show' },
-    { file: 'bindClass' }
+    { file: 'bindClass' },
+    { file: 'bindStyle' }
   ],
   event: [
     {
@@ -45,7 +45,8 @@ const spec = {
         template: { content: getRaw('v-on').originalRaw, code: getRaw('v-on').assertRaw },
       }
     },
-    { file: 'v-on.wxs',
+    {
+      file: 'v-on.wxs',
       sfc: {
         wxs: [{ attrs: { module: 'm' } }],
         template: { content: getRaw('v-on.wxs').originalRaw, code: getRaw('v-on.wxs').assertRaw },
@@ -53,9 +54,9 @@ const spec = {
     }
   ],
   directives: ['v-model']
-}
+};
 
-function createLogger (type) {
+function createLogger(type) {
   return function (...args) {
     // mute silly and info
     if (type === 'silly' || type === 'info') {
@@ -66,7 +67,7 @@ function createLogger (type) {
   };
 }
 
-function createCompiler (options = {}) {
+function createCompiler(options = {}) {
   const instance = new Hook();
   const appConfig = options.appConfig || {};
   const userDefinedTags = appConfig.tags || {};
@@ -77,7 +78,7 @@ function createCompiler (options = {}) {
     warn: createLogger('warn'),
     error: createLogger('error'),
     silly: createLogger('silly'),
-  }
+  };
   instance.tags = {
     htmlTags: tag.combineTag(tag.HTML_TAGS, userDefinedTags.htmlTags),
     wxmlTags: tag.combineTag(tag.WXML_TAGS, userDefinedTags.wxmlTags),
@@ -89,8 +90,7 @@ function createCompiler (options = {}) {
   return instance;
 }
 
-
-function assetHanlder (handlers) {
+function assetHanlder(handlers) {
   for (let id in handlers) {
     for (let type in handlers[id]) {
       const func = handlers[id][type];
@@ -100,7 +100,7 @@ function assetHanlder (handlers) {
       try {
         expect(func.replace(/\s*/ig, '').replace(/\n*/ig, '')).to.equal(fixture.replace(/\s*/ig, '').replace(/\n*/ig, ''));
       } catch (e) {
-        console.log('Compiled Handler: ' + id + '.' + type + '.js')
+        console.log('Compiled Handler: ' + id + '.' + type + '.js');
         console.log(func);
         throw e;
       }
@@ -108,7 +108,7 @@ function assetHanlder (handlers) {
   }
 }
 
-function assertCodegen (originalRaw, assertRaw, options = {}, ctx, done) {
+function assertCodegen(originalRaw, assertRaw, options = {}, ctx, done) {
   const compiler = createCompiler(options);
   compiler.assets.add(ctx.file);
   compiler.hookUnique('template-parse', originalRaw, {}, ctx).then((rst) => {
@@ -124,19 +124,17 @@ function assertCodegen (originalRaw, assertRaw, options = {}, ctx, done) {
 }
 
 describe('template-parse', function () {
-
   spec.attr.forEach(ctx => {
-
     it('test attr: ' + ctx.file, function (done) {
       const { originalRaw, assertRaw } = getRaw(ctx.file);
-      assertCodegen(originalRaw, assertRaw, {}, ctx, done)
-    })
+      assertCodegen(originalRaw, assertRaw, {}, ctx, done);
+    });
   });
-  spec.event.forEach(ctx => {
 
+  spec.event.forEach(ctx => {
     it('test attr: ' + ctx.file, function (done) {
       const { originalRaw, assertRaw } = getRaw(ctx.file);
-      assertCodegen(originalRaw, assertRaw, {}, ctx, done)
-    })
+      assertCodegen(originalRaw, assertRaw, {}, ctx, done);
+    });
   });
 });


### PR DESCRIPTION
修正一个 bug，比如 :style 时用了三元表达式：
```html
<view :style="{ 'background': current === idx ? dotActiveColor : dotColor }"></view>
```
代码会被解析为：
```html
<view style=" {{ 'background:' + current === idx ? dotActiveColor : dotColor + ';' }}"></view>
```

解决方案是用括号恢复优先级。