### PR TITLE
fix(cli): fixed join staticStyle and bindStyle

### DIFF
--- a/packages/cli/core/plugins/template/parse.js
+++ b/packages/cli/core/plugins/template/parse.js
@@ -253,7 +253,10 @@ exports = module.exports = function () {
           });
         }
         if (item.parsedAttr.style || (item.bindStyle && item.bindStyle.length)) {
-          let staticStyle = item.parsedAttr.style || '';
+          let staticStyle = (item.parsedAttr.style || '').trim();
+          if (staticStyle !== '' && /;$/.test(staticStyle) === false) {
+            staticStyle += ';';
+          }
           let bindStyle = (item.bindStyle && item.bindStyle.length) ? ` {{ ${item.bindStyle.join(' + ')} }}` : '';
           str += ` style="${staticStyle + bindStyle}"`;
         }

--- a/packages/cli/test/core/fixtures/template/assert/joinStyle.wxml
+++ b/packages/cli/test/core/fixtures/template/assert/joinStyle.wxml
@@ -1,0 +1,2 @@
+<view style="width: 100rpx; {{ 'background:' + bgColor + ';' }}"></view>
+<view style="height: 200rpx; {{ 'font-size:' + titleFontSize + ';' }}"></view>

--- a/packages/cli/test/core/fixtures/template/original/joinStyle.html
+++ b/packages/cli/test/core/fixtures/template/original/joinStyle.html
@@ -1,0 +1,2 @@
+<div style="width: 100rpx" :style="{ 'background': bgColor }"></div>
+<div style="height: 200rpx;" :style="{ 'font-size': titleFontSize }"></div>

--- a/packages/cli/test/core/plugins/template/parse.test.js
+++ b/packages/cli/test/core/plugins/template/parse.test.js
@@ -8,9 +8,7 @@ const initPlugin = require(`${alias.core}/init/plugin`);
 const moduleSet = require(`${alias.core}/moduleSet`);
 const pt = require(`${alias.plugins}/template/parse`);
 
-
-
-function cached (fn) {
+function cached(fn) {
   var _cache = {};
   return function (key) {
     if (!_cache[key]) {
@@ -35,7 +33,8 @@ const spec = {
     { file: 'v-if' },
     { file: 'v-for' },
     { file: 'v-show' },
-    { file: 'bindClass' }
+    { file: 'bindClass' },
+    { file: 'joinStyle' }
   ],
   event: [
     {
@@ -45,7 +44,8 @@ const spec = {
         template: { content: getRaw('v-on').originalRaw, code: getRaw('v-on').assertRaw },
       }
     },
-    { file: 'v-on.wxs',
+    {
+      file: 'v-on.wxs',
       sfc: {
         wxs: [{ attrs: { module: 'm' } }],
         template: { content: getRaw('v-on.wxs').originalRaw, code: getRaw('v-on.wxs').assertRaw },
@@ -53,9 +53,9 @@ const spec = {
     }
   ],
   directives: ['v-model']
-}
+};
 
-function createLogger (type) {
+function createLogger(type) {
   return function (...args) {
     // mute silly and info
     if (type === 'silly' || type === 'info') {
@@ -66,7 +66,7 @@ function createLogger (type) {
   };
 }
 
-function createCompiler (options = {}) {
+function createCompiler(options = {}) {
   const instance = new Hook();
   const appConfig = options.appConfig || {};
   const userDefinedTags = appConfig.tags || {};
@@ -77,7 +77,7 @@ function createCompiler (options = {}) {
     warn: createLogger('warn'),
     error: createLogger('error'),
     silly: createLogger('silly'),
-  }
+  };
   instance.tags = {
     htmlTags: tag.combineTag(tag.HTML_TAGS, userDefinedTags.htmlTags),
     wxmlTags: tag.combineTag(tag.WXML_TAGS, userDefinedTags.wxmlTags),
@@ -89,8 +89,7 @@ function createCompiler (options = {}) {
   return instance;
 }
 
-
-function assetHanlder (handlers) {
+function assetHanlder(handlers) {
   for (let id in handlers) {
     for (let type in handlers[id]) {
       const func = handlers[id][type];
@@ -100,7 +99,7 @@ function assetHanlder (handlers) {
       try {
         expect(func.replace(/\s*/ig, '').replace(/\n*/ig, '')).to.equal(fixture.replace(/\s*/ig, '').replace(/\n*/ig, ''));
       } catch (e) {
-        console.log('Compiled Handler: ' + id + '.' + type + '.js')
+        console.log('Compiled Handler: ' + id + '.' + type + '.js');
         console.log(func);
         throw e;
       }
@@ -108,7 +107,7 @@ function assetHanlder (handlers) {
   }
 }
 
-function assertCodegen (originalRaw, assertRaw, options = {}, ctx, done) {
+function assertCodegen(originalRaw, assertRaw, options = {}, ctx, done) {
   const compiler = createCompiler(options);
   compiler.assets.add(ctx.file);
   compiler.hookUnique('template-parse', originalRaw, {}, ctx).then((rst) => {
@@ -124,19 +123,16 @@ function assertCodegen (originalRaw, assertRaw, options = {}, ctx, done) {
 }
 
 describe('template-parse', function () {
-
   spec.attr.forEach(ctx => {
-
     it('test attr: ' + ctx.file, function (done) {
       const { originalRaw, assertRaw } = getRaw(ctx.file);
-      assertCodegen(originalRaw, assertRaw, {}, ctx, done)
-    })
+      assertCodegen(originalRaw, assertRaw, {}, ctx, done);
+    });
   });
   spec.event.forEach(ctx => {
-
     it('test attr: ' + ctx.file, function (done) {
       const { originalRaw, assertRaw } = getRaw(ctx.file);
-      assertCodegen(originalRaw, assertRaw, {}, ctx, done)
-    })
+      assertCodegen(originalRaw, assertRaw, {}, ctx, done);
+    });
   });
 });


### PR DESCRIPTION
修正拼接 `style` 与 `:style` 时中间缺少分号的问题。