### PR TITLE
fix: 修复hooks回调异常

### DIFF
--- a/packages/core/dist/wepy.js
+++ b/packages/core/dist/wepy.js
@@ -2156,7 +2156,6 @@ function patchMethods (output, methods, isComponent) {
     }
     child.$evtId = wpyEvt;
     child.$parent = vm;
-    child.$app = vm.$app;
     child.$root = vm.$root;
     return vm;
   };
@@ -2366,6 +2365,9 @@ function patchLifecycle (output, options, rel, isComponent) {
     }
 
     vm.$id = ++comid + (isComponent ? '.1' : '.0');
+    if (isComponent && !vm.$app) {
+      vm.$app = app;
+    }
 
     callUserMethod(vm, vm.$options, 'beforeCreate', args);
 

--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -115,8 +115,8 @@ export function patchLifecycle (output, options, rel, isComponent) {
     }
 
     vm.$id = ++comid + (isComponent ? '.1' : '.0');
-    if (!vm.$app) {
-      // vm.$app = $global.$app;
+    if (isComponent && !vm.$app) {
+      vm.$app = app;
     }
 
     callUserMethod(vm, vm.$options, 'beforeCreate', args);

--- a/packages/core/weapp/init/methods.js
+++ b/packages/core/weapp/init/methods.js
@@ -138,7 +138,6 @@ export function patchMethods (output, methods, isComponent) {
     }
     child.$evtId = wpyEvt;
     child.$parent = vm;
-    child.$app = vm.$app;
     child.$root = vm.$root;
     return vm;
   };


### PR DESCRIPTION
组件的$app属性还未定义导致的异常——Cannot read property 'hooks' of undefined"
应该在created就已经确定了$app，而不是在attached生命周期里

Issue #2414
Closes #2414

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
