### PR TITLE
调整自定义组件注册与Parser组件注册顺序

### DIFF
--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -173,9 +173,9 @@ class Compile extends Hook {
       else if (isArr(paths)) return Promise.all(paths.map(p => copy(p)));
     });
 
-    initPlugin(this);
     initParser(this);
-
+    initPlugin(this);
+    
     this.hook('process-clear', 'init');
 
     return initCompiler(this, this.options.compilers);


### PR DESCRIPTION
`Parser`类组件通过`hookUnique`调用时只会执行最后一次注册的方法，所以自定义插件要想覆盖注入，必须在 `initParser()`之后进行注入