### PR TITLE
test(cli): support bind ref 

### DIFF
--- a/packages/cli/core/plugins/scriptInjection.js
+++ b/packages/cli/core/plugins/scriptInjection.js
@@ -35,7 +35,9 @@ const genRel = rel => {
   delete copy.handlers;
   delete copy.models;
 
-  return `{info: ${JSON.stringify(copy || {})}, handlers: ${handlerStr}, models: ${modelStr} }`;
+  return `{info: ${JSON.stringify(copy || {})}, handlers: ${handlerStr}, models: ${modelStr}, refs: ${JSON.stringify(
+    rel.refs
+  )} }`;
 };
 
 exports = module.exports = function() {

--- a/packages/cli/core/plugins/template/attrs/ref.js
+++ b/packages/cli/core/plugins/template/attrs/ref.js
@@ -1,9 +1,45 @@
 exports = module.exports = function() {
-  this.register('template-parse-ast-attr-ref', function parseRef({ expr }) {
-    return {
-      attrs: {
-        'data-ref': `${expr}`
+  let totalRefCache = {};
+
+  function getParseRefFunc(isBindAttr = false) {
+    return function({ item, ctx, expr, rel }) {
+      let parsedRef = {};
+      let assetsId = this.assets.get(ctx.file);
+      let refCache;
+      let elemId;
+
+      let components = rel.components;
+
+      if (!totalRefCache[assetsId]) {
+        totalRefCache[assetsId] = {
+          increaseId: 0
+        };
       }
+      refCache = totalRefCache[assetsId];
+      elemId = `ref-${assetsId}-${refCache.increaseId}`;
+
+      if (!rel.refs) {
+        rel.refs = [];
+      }
+
+      parsedRef.rel = rel || {};
+      parsedRef.attrs = parsedRef.attrs || {};
+
+      if (!components[item.name]) {
+        parsedRef.attrs['id'] = elemId;
+        rel.refs.push({
+          elemId: elemId,
+          name: `${expr}`,
+          isBindAttr: isBindAttr
+        });
+        refCache.increaseId++;
+      } else {
+        parsedRef.attrs['data-ref'] = isBindAttr ? `{{ ${expr} }}` : `${expr}`;
+      }
+      return parsedRef;
     };
-  });
+  }
+
+  this.register('template-parse-ast-attr-ref', getParseRefFunc().bind(this));
+  this.register('template-parse-ast-attr-:ref', getParseRefFunc(true).bind(this));
 };

--- a/packages/cli/core/plugins/template/attrs/ref.js
+++ b/packages/cli/core/plugins/template/attrs/ref.js
@@ -7,6 +7,7 @@ exports = module.exports = function() {
       let assetsId = this.assets.get(ctx.file);
       let refCache;
       let elemId;
+      let selector;
 
       let components = rel.components;
 
@@ -17,6 +18,7 @@ exports = module.exports = function() {
       }
       refCache = totalRefCache[assetsId];
       elemId = `ref-${assetsId}-${refCache.increaseId}`;
+      selector = `#${elemId}`;
 
       if (!rel.refs) {
         rel.refs = [];
@@ -28,9 +30,9 @@ exports = module.exports = function() {
       if (!components[item.name]) {
         parsedRef.attrs['id'] = elemId;
         rel.refs.push({
-          elemId: elemId,
+          selector: selector,
           name: `${expr}`,
-          isBindAttr: isBindAttr
+          bind: isBindAttr
         });
         refCache.increaseId++;
       } else {

--- a/packages/cli/core/plugins/template/parse.js
+++ b/packages/cli/core/plugins/template/parse.js
@@ -85,7 +85,8 @@ exports = module.exports = function() {
         hook = 'template-parse-ast-attr-[other]';
       }
 
-      parsed = this.hookUnique(hook, { item, name, expr, modifiers, scope, ctx });
+      parsed = this.hookUnique(hook, { item, name, expr, modifiers, scope, ctx, rel });
+      rel = parsed.rel || rel;
 
       let applyHook = parsed.hook || `template-parse-ast-attr-${name}-apply`;
       if (!this.hasHook(applyHook)) {

--- a/packages/cli/test/core/fixtures/template/assert/ref.wxml
+++ b/packages/cli/test/core/fixtures/template/assert/ref.wxml
@@ -1,0 +1,3 @@
+<view id="ref-0-0"></view>
+<custom-component-01 bind_init="_initComponent" data-ref="myCom01"></custom-component-01>
+<custom-component-02 bind_init="_initComponent" data-ref="myCom02"></custom-component-02>

--- a/packages/cli/test/core/fixtures/template/assert/ref.wxml
+++ b/packages/cli/test/core/fixtures/template/assert/ref.wxml
@@ -1,3 +1,4 @@
 <view id="ref-0-0"></view>
+<view id="ref-0-1"></view>
 <custom-component-01 bind_init="_initComponent" data-ref="myCom01"></custom-component-01>
 <custom-component-02 bind_init="_initComponent" data-ref="myCom02"></custom-component-02>

--- a/packages/cli/test/core/fixtures/template/original/ref.html
+++ b/packages/cli/test/core/fixtures/template/original/ref.html
@@ -1,3 +1,4 @@
-<div :ref="value"></div>
+<div :ref="value01"></div>
+<div :ref="value02"></div>
 <custom-component-01 ref="myCom01" ></custom-component-01>
 <custom-component-02 ref="myCom02"></custom-component-02>

--- a/packages/cli/test/core/fixtures/template/original/ref.html
+++ b/packages/cli/test/core/fixtures/template/original/ref.html
@@ -1,0 +1,3 @@
+<div :ref="value"></div>
+<custom-component-01 ref="myCom01" ></custom-component-01>
+<custom-component-02 ref="myCom02"></custom-component-02>

--- a/packages/cli/test/core/plugins/template/parse.test.js
+++ b/packages/cli/test/core/plugins/template/parse.test.js
@@ -34,7 +34,14 @@ const spec = {
     { file: 'v-show' },
     { file: 'bindClass' },
     { file: 'joinStyle' },
-    { file: 'attrWithoutValue' }
+    { file: 'attrWithoutValue' },
+    {
+      file: 'ref',
+      component: {
+        'custom-component-01': '~@/component/custom-component-01',
+        'custom-component-02': '~@/component/custom-component-02'
+      }
+    }
   ],
   event: [
     {
@@ -117,7 +124,7 @@ function assertCodegen(originalRaw, assertRaw, options = {}, ctx, done) {
   const compiler = createCompiler(options);
   compiler.assets.add(ctx.file);
   compiler
-    .hookUnique('template-parse', originalRaw, {}, ctx)
+    .hookUnique('template-parse', originalRaw, options.component || {}, ctx)
     .then(rst => {
       expect(rst.code).to.equal(assertRaw);
       if (ctx.file === 'v-on') {
@@ -135,14 +142,14 @@ describe('template-parse', function() {
   spec.attr.forEach(ctx => {
     it('test attr: ' + ctx.file, function(done) {
       const { originalRaw, assertRaw } = getRaw(ctx.file);
-      assertCodegen(originalRaw, assertRaw, {}, ctx, done);
+      assertCodegen(originalRaw, assertRaw, ctx, ctx, done);
     });
   });
 
   spec.event.forEach(ctx => {
     it('test attr: ' + ctx.file, function(done) {
       const { originalRaw, assertRaw } = getRaw(ctx.file);
-      assertCodegen(originalRaw, assertRaw, {}, ctx, done);
+      assertCodegen(originalRaw, assertRaw, ctx, ctx, done);
     });
   });
 });

--- a/packages/core/dist/wepy.js
+++ b/packages/core/dist/wepy.js
@@ -2402,6 +2402,8 @@ function patchLifecycle(output, options, rel, isComponent) {
       var acceptProps = this.properties;
       var vm = this.$wepy;
 
+      this.triggerEvent('_init', vm);
+
       // created 不能调用 setData，如果有 dirty 在此更新
       vm.$forceUpdate();
 
@@ -2424,6 +2426,24 @@ function patchLifecycle(output, options, rel, isComponent) {
       var currentPage = pages[pages.length - 1];
       var path = currentPage.__route__;
       var webViewId = currentPage.__wxWebviewId__;
+
+      var refs = rel.refs || [];
+      var query = wx.createSelectorQuery();
+
+      refs.forEach(function (item) {
+        var elemId = item.elemId;
+        var actualAttrName = item.name;
+
+        if (item.isBindAttr) {
+          // if this is a bind attr
+          actualAttrName = vm[item.name];
+          vm.$watch(item.name, function (newAttrName, oldAttrName) {
+            vm.$refs[oldAttrName] = null;
+            vm.$refs[newAttrName] = query.select(("#" + elemId));
+          });
+        }
+        vm.$refs[actualAttrName] = query.select(("#" + elemId));
+      });
 
       // created 不能调用 setData，如果有 dirty 在此更新
       vm.$forceUpdate();

--- a/packages/core/dist/wepy.js
+++ b/packages/core/dist/wepy.js
@@ -2431,18 +2431,18 @@ function patchLifecycle(output, options, rel, isComponent) {
       var query = wx.createSelectorQuery();
 
       refs.forEach(function (item) {
-        var elemId = item.elemId;
+        var selector = item.selector;
         var actualAttrName = item.name;
 
-        if (item.isBindAttr) {
+        if (item.bind) {
           // if this is a bind attr
           actualAttrName = vm[item.name];
-          vm.$watch(item.name, function (newAttrName, oldAttrName) {
+          vm.$watch(item.name, function(newAttrName, oldAttrName) {
             vm.$refs[oldAttrName] = null;
-            vm.$refs[newAttrName] = query.select(("#" + elemId));
+            vm.$refs[newAttrName] = query.select(selector);
           });
         }
-        vm.$refs[actualAttrName] = query.select(("#" + elemId));
+        vm.$refs[actualAttrName] = query.select(selector);
       });
 
       // created 不能调用 setData，如果有 dirty 在此更新

--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -147,6 +147,8 @@ export function patchLifecycle(output, options, rel, isComponent) {
       let acceptProps = this.properties;
       let vm = this.$wepy;
 
+      this.triggerEvent('_init', vm);
+
       // created 不能调用 setData，如果有 dirty 在此更新
       vm.$forceUpdate();
 
@@ -166,6 +168,24 @@ export function patchLifecycle(output, options, rel, isComponent) {
       let currentPage = pages[pages.length - 1];
       let path = currentPage.__route__;
       let webViewId = currentPage.__wxWebviewId__;
+
+      let refs = rel.refs || [];
+      let query = wx.createSelectorQuery();
+
+      refs.forEach(item => {
+        let elemId = item.elemId;
+        let actualAttrName = item.name;
+
+        if (item.isBindAttr) {
+          // if this is a bind attr
+          actualAttrName = vm[item.name];
+          vm.$watch(item.name, function(newAttrName, oldAttrName) {
+            vm.$refs[oldAttrName] = null;
+            vm.$refs[newAttrName] = query.select(`#${elemId}`);
+          });
+        }
+        vm.$refs[actualAttrName] = query.select(`#${elemId}`);
+      });
 
       // created 不能调用 setData，如果有 dirty 在此更新
       vm.$forceUpdate();

--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -173,18 +173,18 @@ export function patchLifecycle(output, options, rel, isComponent) {
       let query = wx.createSelectorQuery();
 
       refs.forEach(item => {
-        let elemId = item.elemId;
+        let selector = item.selector;
         let actualAttrName = item.name;
 
-        if (item.isBindAttr) {
+        if (item.bind) {
           // if this is a bind attr
           actualAttrName = vm[item.name];
           vm.$watch(item.name, function(newAttrName, oldAttrName) {
             vm.$refs[oldAttrName] = null;
-            vm.$refs[newAttrName] = query.select(`#${elemId}`);
+            vm.$refs[newAttrName] = query.select(selector);
           });
         }
-        vm.$refs[actualAttrName] = query.select(`#${elemId}`);
+        vm.$refs[actualAttrName] = query.select(selector);
       });
 
       // created 不能调用 setData，如果有 dirty 在此更新


### PR DESCRIPTION
#1789 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

##### documentation
ref 被用来给元素或子组件注册引用信息。引用信息将会注册在父组件的 $refs 对象上。如果在普通的小程序元素上使用，引用指向的就是小程序元素 SelectorQuery 对象实例；如果用在子组件上，引用就指向组件实例：
```vue
<template>
  <!-- `vm.$refs.view` will be the weapp SelectorQuery node -->
  <view ref="view">hello</view>
  <!-- `vm.$refs.view2` will be the weapp SelectorQuery node -->
  <view :ref="viewRefValue">hello</view>

  <!-- `vm.$refs.child` will be the child component instance -->
  <child-component ref="child"></child-component>
  <!-- `vm.$refs.child2` will be the child component instance -->
  <child-component :ref="childRefValue"></child-component>
</template>
<script>
// ...
data: {
  viewRefValue: 'view2',
  childRefValue: 'child2'
}
</script>
```
暂不支持在 `v-for` 中使用 `ref` 特性