### PR TITLE
fix: fixed ref not work when id and ref attr exist at the same time

### DIFF
--- a/packages/cli/test/core/fixtures/template/assert/ref.wxml
+++ b/packages/cli/test/core/fixtures/template/assert/ref.wxml
@@ -1,4 +1,6 @@
 <view id="ref-0-0"></view>
 <view id="ref-0-1"></view>
+<view id="hello"></view>
+<view id="{{ hello }}"></view>
 <custom-component-01 bind_init="_initComponent" data-ref="myCom01"></custom-component-01>
-<custom-component-02 bind_init="_initComponent" data-ref="myCom02"></custom-component-02>
+<custom-component-02 bind_init="_initComponent" data-ref="{{ myCom02 }}"></custom-component-02>

--- a/packages/cli/test/core/fixtures/template/original/ref.html
+++ b/packages/cli/test/core/fixtures/template/original/ref.html
@@ -1,4 +1,6 @@
 <div :ref="value01"></div>
 <div :ref="value02"></div>
+<div id="hello" :ref="value03"></div>
+<div :id="hello" :ref="value04"></div>
 <custom-component-01 ref="myCom01" ></custom-component-01>
-<custom-component-02 ref="myCom02"></custom-component-02>
+<custom-component-02 :ref="myCom02"></custom-component-02>

--- a/packages/core/dist/wepy.js
+++ b/packages/core/dist/wepy.js
@@ -2431,18 +2431,38 @@ function patchLifecycle(output, options, rel, isComponent) {
       var query = wx.createSelectorQuery();
 
       refs.forEach(function (item) {
-        var selector = item.selector;
-        var actualAttrName = item.name;
+        // {
+        //   id: { name: 'hello', bind: true },
+        //   ref: { name: 'value', bind: false }
+        // }
+        var idAttr = item.id;
+        var refAttr = item.ref;
+        var actualAttrIdName = idAttr.name;
+        var actualAttrRefName = refAttr.name;
+        var selector = "#" + actualAttrIdName;
 
-        if (item.bind) {
-          // if this is a bind attr
-          actualAttrName = vm[item.name];
-          vm.$watch(item.name, function(newAttrName, oldAttrName) {
+        if (idAttr.bind) {
+          // if id is a bind attr
+          actualAttrIdName = vm[idAttr.name];
+          selector = "#" + actualAttrIdName;
+          vm.$watch(idAttr.name, function(newAttrName) {
+            actualAttrIdName = newAttrName;
+            selector = "#" + actualAttrIdName;
+            vm.$refs[actualAttrRefName] = query.select(selector);
+          });
+        }
+
+        if (refAttr.bind) {
+          // if ref is a bind attr
+          actualAttrRefName = vm[refAttr.name];
+
+          vm.$watch(refAttr.name, function(newAttrName, oldAttrName) {
+            actualAttrRefName = newAttrName;
             vm.$refs[oldAttrName] = null;
             vm.$refs[newAttrName] = query.select(selector);
           });
         }
-        vm.$refs[actualAttrName] = query.select(selector);
+        vm.$refs[actualAttrRefName] = query.select(selector);
       });
 
       // created 不能调用 setData，如果有 dirty 在此更新

--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -173,18 +173,38 @@ export function patchLifecycle(output, options, rel, isComponent) {
       let query = wx.createSelectorQuery();
 
       refs.forEach(item => {
-        let selector = item.selector;
-        let actualAttrName = item.name;
+        // {
+        //   id: { name: 'hello', bind: true },
+        //   ref: { name: 'value', bind: false }
+        // }
+        let idAttr = item.id;
+        let refAttr = item.ref;
+        let actualAttrIdName = idAttr.name;
+        let actualAttrRefName = refAttr.name;
+        let selector = `#${actualAttrIdName}`;
 
-        if (item.bind) {
-          // if this is a bind attr
-          actualAttrName = vm[item.name];
-          vm.$watch(item.name, function(newAttrName, oldAttrName) {
+        if (idAttr.bind) {
+          // if id is a bind attr
+          actualAttrIdName = vm[idAttr.name];
+          selector = `#${actualAttrIdName}`;
+          vm.$watch(idAttr.name, function(newAttrName) {
+            actualAttrIdName = newAttrName;
+            selector = `#${actualAttrIdName}`;
+            vm.$refs[actualAttrRefName] = query.select(selector);
+          });
+        }
+
+        if (refAttr.bind) {
+          // if ref is a bind attr
+          actualAttrRefName = vm[refAttr.name];
+
+          vm.$watch(refAttr.name, function(newAttrName, oldAttrName) {
+            actualAttrRefName = newAttrName;
             vm.$refs[oldAttrName] = null;
             vm.$refs[newAttrName] = query.select(selector);
           });
         }
-        vm.$refs[actualAttrName] = query.select(selector);
+        vm.$refs[actualAttrRefName] = query.select(selector);
       });
 
       // created 不能调用 setData，如果有 dirty 在此更新


### PR DESCRIPTION
#### Checklist

- [x] `npm run test` passes
- [x] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

#### documentation
ref 被用来给元素或子组件注册引用信息。引用信息将会注册在父组件的 $refs 对象上。如果在普通的小程序元素上使用，引用指向的就是小程序元素 SelectorQuery 对象实例；如果用在子组件上，引用就指向组件实例：
```vue
<template>
  <!-- `vm.$refs.view` will be the weapp SelectorQuery node -->
  <view ref="view">hello</view>
  <!-- `vm.$refs.view2` will be the weapp SelectorQuery node -->
  <view :ref="viewRefValue">hello</view>

  <!-- `vm.$refs.child` will be the child component instance -->
  <child-component ref="child"></child-component>
  <!-- `vm.$refs.child2` will be the child component instance -->
  <child-component :ref="childRefValue"></child-component>
</template>
<script>
// ...
data: {
  viewRefValue: 'view2',
  childRefValue: 'child2'
}
</script>
```
暂不支持在 `v-for` 中使用 `ref` 特性

##### 原理
ref 被用来给普通小程序元素注册引用信息

编译期检测到元素有使用 ref 属性时，会动态给元素创建一个唯一 id，通过代码注入的方式传入运行时的 `page` 构造器。

运行时中，通过获取构造器中的 `id` 和 `ref` 信息，页面会在  `attach` 生命周期中创建元素的节点 SelectorQuery 对象并初始化页面实例的 `$refs` 属性

#### Bug fixes

##### 问题描述
当某个小程序元素 id 与 ref 属性同时存在时，如：

- 编译前

```vue
<view id="myId" ref="myRef"></view>

//...

{
  myLogic () {
    const query = SelectorQuery.select('#myId')
    // ...
  }
}
```

由于之前没有对这种情况进行兼容，编译后会导致初始的 id 原始值被覆盖，可能导致代码逻辑出错：

- 编译后

```vue
// after compiler
<view id="ref-0-0"></view>

//...

{
  myLogic () {
    const query = SelectorQuery.select('#myId') // throw Error
    // ...
  }
}
```
##### 修复后

- 编译前

```vue
// compiler before
<view id="myId" ref="myRef"></view>

//...

{
  myLogic () {
    const query = SelectorQuery.select('#myId')
    // ...
  }
}
```

- 编译后

```vue
// after compiler
<view id="myId"></view>

//...

{
  myLogic () {
    const query = SelectorQuery.select('#myId') // throw Error
    // ...
  }
}
```
除此之外，还顺便支持了动态 `id` 属性 与 `ref` 属性同时存在的情形：

```vue
<view :id="myId" ref="myRef"></view>
<button @tap="changeIdHandler">
//...

{
  data: {
    myId: 'id_01'
  },
  methods: {
   changeIdHandler () {
    this.myId = 'id_02' 
    this.$nextTick(() => {
      const view = this.$refs.myRef
     console.log('ref: ', view)
    // => {_selectorQuery: n, _component: null, _selector: "#id_02", _single: true}
    })
  }
 },
  onLoad () {
     const view = this.$refs.myRef
    console.log('ref: ', view)
   // => {_selectorQuery: n, _component: null, _selector: "#id_01", _single: true}
  }
}
```
