### PR TITLE
fix(core): #2448

### DIFF
--- a/packages/core/weapp/observer/scheduler.js
+++ b/packages/core/weapp/observer/scheduler.js
@@ -39,13 +39,16 @@ function flushSchedulerQueue(times = 0) {
   //    user watchers are created before the render watcher)
   // 3. If a component is destroyed during a parent component's watcher run,
   //    its watchers can be skipped.
-  queue.sort((a, b) => a.id - b.id);
+  times === 0 && queue.sort((a, b) => a.id - b.id);
 
   // do not cache length because more watchers might be pushed
   // as we run existing watchers
   // there would be mutilple renderWatcher in the queue.
   let renderWatcher = [];
-  for (index = 0; index < queue.length; index++) {
+  if (times === 0) {
+    index = 0;
+  }
+  for (; index < queue.length; index++) {
     // if it's renderWatcher, run it in the end
     watcher = queue[index];
     if (watcher && watcher.isRenderWatcher) {


### PR DESCRIPTION
fix(core): #2448
原因是 flushSchedulerQueue  里，递归调用时，index 每次都从 0 开始。并且每次调用后 pendingQueue 都不为空， 因此递归无法终止