### PR TITLE
do not change the path of a component when it is using the official plugin

### DIFF
--- a/packages/cli/core/plugins/build/components.js
+++ b/packages/cli/core/plugins/build/components.js
@@ -25,7 +25,11 @@ exports = module.exports = function() {
        * }
        */
       for (let i in usingComponents) {
-        newUsingComponents[i] = './' + usingComponents[i].replace(/\\/g, '/');
+        if (usingComponents[i].startsWith('plugin://')) {
+          newUsingComponents[i] = usingComponents[i];
+        } else {
+          newUsingComponents[i] = './' + usingComponents[i].replace(/\\/g, '/');
+        }
       }
       let output = {
         ...other,


### PR DESCRIPTION
The test script is failed without any change, so I didn't have a test case, sorry for that.

This bug is very urgent, after updating the version from `2.0.20` to `2.0.22`, our chatbot plugin in Wechat miniprogram can't be loaded with an error message.

> jsEnginScriptError
Component is not found in path "foundation/pages/plugin:/chatbot/chat" (using by "foundation/pages/chatbot");onAppRoute
Error: Component is not found in path "foundation/pages/plugin:/chatbot/chat" (using by "foundation/pages/chatbot")

The root reason is because the WePY built the path of the plugin from 
```json
  {
    "component": true,
    "usingComponents": {
      "chat": "plugin://chatbot/chat"
    }
  }
```
to
```json
{
    "component": true,
    "usingComponents": {
        "chat": "./plugin://chatbot/chat"
    }
}
```

This PR is just for fixing this bug.