### PR TITLE
feat(wepy-compiler-sass): 添加对 node-sass data 字段配置的支持

### DIFF
--- a/packages/wepy-compiler-sass/src/index.js
+++ b/packages/wepy-compiler-sass/src/index.js
@@ -13,6 +13,9 @@ import sass from 'node-sass';
 export default function (content, config, file) {
     let result = {};
     return new Promise ((resolve, reject) => {
+        if (typeof config.data === 'string') {
+          content = config.data + content;
+        }
         config.data = content;
         config.file = file;
         sass.render(config, (err, res) => {


### PR DESCRIPTION
解决 无法添加全局 scss 的问题
使用示例:
```
sass: {
    data: '$color: lightblue;'
}
```

但无法直接使用以下方式引入scss文件（可能是不支持对路径的解析导致）
```
sass: {
    data: '@import "@/static/css/_var.scss";'
}
```

当需要引入scss文件时，可使用如下方式：
```
const fs = require('fs')
const commonScss = fs.readFileSync('./src/static/css/_var.scss')

sass: {
    data: commonScss
}
```