### PR TITLE
Fix TypeScript type definition bug

### DIFF
--- a/packages/cli/core/plugins/template/directives/condition.js
+++ b/packages/cli/core/plugins/template/directives/condition.js
@@ -1,18 +1,8 @@
-const decodingMap = {
-  '&lt;': '<',
-  '&gt;': '>',
-  '&amp;': '&',
-};
-
-function decodeAttr(value, shouldDecodeNewlines) {
-  return value.replace(/&(?:lt|gt|amp);/g, function (match) { return decodingMap[match]; })
-}
-
 const ADDITIONS_DIRECTIVES_HANDLES = {
   /* eslint-disable no-unused-vars */
-  'v-show': ({ item, name, expr }) => ({ attrs: { hidden: `{{ !(${decodeAttr(expr)}) }}` } }),
-  'v-if': ({ item, name, expr }) => ({ attrs: { 'wx:if': `{{ ${decodeAttr(expr)} }}` } }),
-  'v-else-if': ({ item, name, expr }) => ({ attrs: { 'wx:elif': `{{ ${decodeAttr(expr)} }}` } }),
+  'v-show': ({ item, name, expr }) => ({ attrs: { hidden: `{{ !(${expr}) }}` } }),
+  'v-if': ({ item, name, expr }) => ({ attrs: { 'wx:if': `{{ ${expr} }}` } }),
+  'v-else-if': ({ item, name, expr }) => ({ attrs: { 'wx:elif': `{{ ${expr} }}` } }),
   'v-else': ({ item, name, expr }) => ({ attrs: { 'wx:else': true } })
   /* eslint-enable no-unused-vars */
 };

--- a/packages/cli/core/plugins/template/directives/condition.js
+++ b/packages/cli/core/plugins/template/directives/condition.js
@@ -1,8 +1,18 @@
+const decodingMap = {
+  '&lt;': '<',
+  '&gt;': '>',
+  '&amp;': '&',
+};
+
+function decodeAttr(value, shouldDecodeNewlines) {
+  return value.replace(/&(?:lt|gt|amp);/g, function (match) { return decodingMap[match]; })
+}
+
 const ADDITIONS_DIRECTIVES_HANDLES = {
   /* eslint-disable no-unused-vars */
-  'v-show': ({ item, name, expr }) => ({ attrs: { hidden: `{{ !(${expr}) }}` } }),
-  'v-if': ({ item, name, expr }) => ({ attrs: { 'wx:if': `{{ ${expr} }}` } }),
-  'v-else-if': ({ item, name, expr }) => ({ attrs: { 'wx:elif': `{{ ${expr} }}` } }),
+  'v-show': ({ item, name, expr }) => ({ attrs: { hidden: `{{ !(${decodeAttr(expr)}) }}` } }),
+  'v-if': ({ item, name, expr }) => ({ attrs: { 'wx:if': `{{ ${decodeAttr(expr)} }}` } }),
+  'v-else-if': ({ item, name, expr }) => ({ attrs: { 'wx:elif': `{{ ${decodeAttr(expr)} }}` } }),
   'v-else': ({ item, name, expr }) => ({ attrs: { 'wx:else': true } })
   /* eslint-enable no-unused-vars */
 };

--- a/packages/core/types/options.d.ts
+++ b/packages/core/types/options.d.ts
@@ -19,18 +19,18 @@ type DataDef<Data, Props, V> = Data | ((this: Readonly<Props> & V) => Data)
 /**
  * This type should be used when an array of strings is used for a component's `props` value.
  */
-export type ThisTypedComponentOptionsWithArrayProps<V extends WepyInstace, Data, Methods, Computed, PropNames extends string> =
+export type ThisTypedComponentOptionsWithArrayProps<V extends WepyInstace, Data, Methods, Hooks, Computed, PropNames extends string> =
   object &
-  ComponentOptions<V, DataDef<Data, Record<PropNames, any>, V>, Methods, Computed, PropNames[], Record<PropNames, any>> &
-  ThisType<CombineWepyInstance<V, Data, Methods, Computed, Readonly<Record<PropNames, any>>>>;
+  ComponentOptions<V, DataDef<Data, Record<PropNames, any>, V>, Methods, Hooks, Computed, PropNames[], Record<PropNames, any>> &
+  ThisType<CombineWepyInstance<V, Data, Methods, Hooks, Computed, Readonly<Record<PropNames, any>>>>;
 
 /**
  * This type should be used when an object mapped to `PropOptions` is used for a component's `props` value.
  */
-export type ThisTypedComponentOptionsWithRecordProps<V extends WepyInstace, Data, Methods, Computed, Props> =
+export type ThisTypedComponentOptionsWithRecordProps<V extends WepyInstace, Data, Methods, Hooks, Computed, Props> =
   object &
-  ComponentOptions<V, DataDef<Data, Props, V>, Methods, Computed, RecordPropsDefinition<Props>, Props> &
-  ThisType<CombineWepyInstance<V, Data, Methods, Computed, Readonly<Props>>>;
+  ComponentOptions<V, DataDef<Data, Props, V>, Methods, Hooks, Computed, RecordPropsDefinition<Props>, Props> &
+  ThisType<CombineWepyInstance<V, Data, Methods, Hooks, Computed, Readonly<Props>>>;
 
 type DefaultData<V> =  object | ((this: V) => object);
 type DefaultProps = Record<string, any>;
@@ -50,14 +50,14 @@ export interface ComponentOptions<
   V extends WepyInstace,
   Data=DefaultData<V>,
   Methods=DefaultMethods<V>,
-  // Hooks=DefaultHooks<V>,
+  Hooks=DefaultHooks<V>,
   Computed=DefaultComputed,
   PropsDef=PropsDefinition<DefaultProps>,
   Props=DefaultProps> extends wepy.Page.PageInstance {
   data?: Data;
   props?: PropsDef;
   propsData?: object;
-  // hooks?: Hooks;
+  hooks?: Hooks;
   computed?: Accessors<Computed>;
   methods?: Methods;
   watch?: Record<string, WatchOptionsWithHandler<any> | WatchHandler<any> | string>;

--- a/packages/core/types/options.d.ts
+++ b/packages/core/types/options.d.ts
@@ -50,14 +50,14 @@ export interface ComponentOptions<
   V extends WepyInstace,
   Data=DefaultData<V>,
   Methods=DefaultMethods<V>,
-  Hooks=DefaultHooks<V>,
+  // Hooks=DefaultHooks<V>,
   Computed=DefaultComputed,
   PropsDef=PropsDefinition<DefaultProps>,
   Props=DefaultProps> extends wepy.Page.PageInstance {
   data?: Data;
   props?: PropsDef;
   propsData?: object;
-  hooks?: Hooks;
+  // hooks?: Hooks;
   computed?: Accessors<Computed>;
   methods?: Methods;
   watch?: Record<string, WatchOptionsWithHandler<any> | WatchHandler<any> | string>;

--- a/packages/core/types/wepy.d.ts
+++ b/packages/core/types/wepy.d.ts
@@ -86,7 +86,7 @@ export interface Vue {
   $nextTick(): Promise<void>;
 }
 
-export type CombineWepyInstance<Instance extends WepyInstace, Data, Methods, Computed, Props> =  Data & Methods & Computed & Props & Instance;
+export type CombineWepyInstance<Instance extends WepyInstace, Data, Methods, Hooks, Computed, Props> =  Data & Methods & Hooks & Computed & Props & Instance;
 
 export interface WepyConfiguration {
   silent: boolean;
@@ -97,12 +97,12 @@ export interface WepyConstructor<V extends WepyInstace = WepyInstace, P extends 
 
   app(options: AppOptions<WepyApp>): void;
 
-  page<Data, Methods, Computed, PropNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<P, Data, Methods, Computed, PropNames>): wepy.Page.PageInstance;
-  page<Data, Methods, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<P, Data, Methods, Computed, Props>): wepy.Page.PageInstance;
+  page<Data, Methods, Hooks, Computed, PropNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<P, Data, Methods, Hooks, Computed, PropNames>): wepy.Page.PageInstance;
+  page<Data, Methods, Hooks, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<P, Data, Methods, Hooks, Computed, Props>): wepy.Page.PageInstance;
   page(options?: ComponentOptions<P>): wepy.Page.PageInstance;
 
-  component<Data, Methods, Computed, PropNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<C, Data, Methods, Computed, PropNames>): wepy.Page.PageInstance;
-  component<Data, Methods, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<C, Data, Methods, Computed, Props>): wepy.Page.PageInstance;
+  component<Data, Methods, Hooks, Computed, PropNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<C, Data, Methods, Hooks, Computed, PropNames>): wepy.Page.PageInstance;
+  component<Data, Methods, Hooks, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<C, Data, Methods, Hooks, Computed, Props>): wepy.Page.PageInstance;
   component(options?: ComponentOptions<C>): wepy.Page.PageInstance;
 
   nextTick<T>(callback: (this: T) => void, context?: T): void;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

在使用 TypeScript 时发现问题，观察到该文件（`options.d.ts`）第 24 行：

```typescript
ComponentOptions<V, DataDef<Data, Record<PropNames, any>, V>, Methods, Computed, PropNames[], Record<PropNames, any>>
```

以及第 32 行：

```typescript
ComponentOptions<V, DataDef<Data, Props, V>, Methods, Computed, RecordPropsDefinition<Props>, Props>
```

调用 `ComponentOptions` 时传递了六个参数，而该类型的定义为（第 49 行至第 77 行，截取参数部分）：

```typescript
export interface ComponentOptions<
  V extends WepyInstace,
  Data=DefaultData<V>,
  Methods=DefaultMethods<V>,
  Hooks=DefaultHooks<V>,
  Computed=DefaultComputed,
  PropsDef=PropsDefinition<DefaultProps>,
  Props=DefaultProps> extends wepy.Page.PageInstance {
```

传入了 7 个参数。

经比对，发现第四个参数 `Hooks` 没有被使用，因此调用时的 `Computed` 被错误地传入了 `Hooks` 里，后面的以此类推，第七个参数被迫使用默认值。

翻阅文档，未发现有 Hooks 的任何记载（可能我看得不仔细），因此先注释掉（以及返回类型里用到 `Hooks` 的 `hooks`），如果确定该参数多余，再将其删掉。