### PR TITLE
Global components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,14 +22,5 @@
     "no-empty": 0,
     "yoda": 0,
     "no-new-func": 0
-  },
-  "globals": {
-    App,
-    Page,
-    wx,
-    __VERSION__,
-    Component
-  },
-  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
-  plugins: ['prettier']
+  }
 }

--- a/packages/cli/core/plugins/parser/config.js
+++ b/packages/cli/core/plugins/parser/config.js
@@ -57,8 +57,6 @@ exports = module.exports = function() {
           if (comp.prefix === 'module') {
             targetPath = comp.target;
           }
-          const relativePath = path.relative(path.dirname(ctx.file), targetPath);
-          const parsedPath = path.parse(relativePath);
         }
       });
     }

--- a/packages/cli/core/plugins/parser/config.js
+++ b/packages/cli/core/plugins/parser/config.js
@@ -38,7 +38,6 @@ exports = module.exports = function() {
     }
 
     let userDefineComponents = config.usingComponents || {};
-    let appDefinedComponents = {};
     let componentKeys = Object.keys(config.usingComponents);
 
     if (!appUsingComponents && componentKeys.length === 0) {
@@ -60,8 +59,6 @@ exports = module.exports = function() {
           }
           const relativePath = path.relative(path.dirname(ctx.file), targetPath);
           const parsedPath = path.parse(relativePath);
-          // Remove wpy ext
-          appDefinedComponents[comp.name] = path.join(parsedPath.dir, parsedPath.name);
         }
       });
     }

--- a/packages/use-intercept/package.json
+++ b/packages/use-intercept/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepy/use-intercept",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "wepy intercept",
   "main": "/dist/index.js",
   "scripts": {
@@ -12,6 +12,6 @@
   },
   "license": "MIT",
   "readme": "ERROR: No README data found!",
-  "_id": "@wepy/use-intercept@2.0.3",
-  "_commitid": "0cf8086"
+  "_id": "@wepy/use-intercept@2.0.4",
+  "_commitid": "2fd06e4"
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [x] cases or donate is changed or added
- [x] documentation is changed or added
1. add useComponents in app.json
2. remove global components from page's json file
3. compile component file in app.json
#2559 
在windows系统中使用全局组件的时候发现一个问题。
重现过程如下
1. 在src/components/ 中创建组件a.wpy
2. 在app.wpy的config 中useComponents引用a.wpy，
```
useComponents:{
 a: "component/a"
}
```
3. 在编译的weapp/app.json中并没有useComponents属性。在weapp/components文件夹中也无对应组件的编译文件。
4. 在每个页面及组件的 json文件中的 useComponents 都能发现一个配置项
```
 a:"..\\components\\a"
```
- 初步判断原因应该是全局组件解析path时文件路径都为 '..\\..\\'形式，JS无法解析导致页面打包时找不到对应的文件，因此打包被跳过
- 由于该a组件的编译文件并没有被打包到 weapp/components 文件夹中，且该应用方式不能被JS解析，导致页面中引用组件报错，不能正常使用a组件。
- 同时a组件会在所有页面及组件进行引用，无形中会细微的增加一点打包体积。

因此原来的全局组件打包方式亟需需要优化

研究@wepy/cli/core发现在代码中找到现在实现全局组件的方式
1. 在解析config 时，app.json中的useComponents 被删掉，然后添加进每个页面及组件内
```
#  @wepy/cli/core/plugins/parser/config.js
126     if (ctx.type === 'app') {
127        appUsingComponents = parseComponents;
128        delete config.usingComponents;
129      } else {
130        config.usingComponents = Object.assign({}, resolvedUsingComponents, appDefinedComponents);
131      }
```

2. 在进行文件打包的时候，全局组件被遗忘，并没有被打包进weapp中

```
# @wepy/cli/core/compile.js
中只对page文件打包，并没有对useComponents中的组件进行打包
```


针对以上两个问题，对cli代码做了两处修改
1. @wepy/cli/core/plugins/parser/config.js 中 保留 app.json中的useComponents字段，并不在继续将全局组件的配置写入页面和其他组件
```
#  @wepy/cli/core/plugins/parser/config.js
126     if (ctx.type === 'app') {
127        appUsingComponents = parseComponents;
128      } else {
129        config.usingComponents = Object.assign({}, resolvedUsingComponents);
130      }
```
2. 增加全局组件打包
```
# @wepy/cli/core/compile.js
        let pageTasks = pages.map(v => {
          let file;

          file = v + this.options.wpyExt;
          if (fs.existsSync(file)) {
            return this.hookUnique('wepy-parser-wpy', { path: file, type: 'page' });
          }
          file = v + '.js';
          if (fs.existsSync(file)) {
            return this.hookUnique('wepy-parser-component', { path: file, type: 'page', npm: false });
          }
          this.hookUnique('error-handler', {
            type: 'error',
            ctx: app,
            message: `Can not resolve page: ${v}`
          });
        });

        let components = [];
        if (appConfig.usingComponents) {
          for (let key in appConfig.usingComponents) {
            let v = appConfig.usingComponents[key];
            components.push(path.resolve(app.file, '../', v));
          }
        }

        let componentsTask = components.map(v => {
          let file;

          file = v + this.options.wpyExt;
          if (fs.existsSync(file)) {
            return this.hookUnique('wepy-parser-wpy', { path: file, type: 'wepy' });
          }
          file = v + '.js';
          if (fs.existsSync(file)) {
            return this.hookUnique('wepy-parser-component', { path: file, type: 'wepy', npm: false });
          }
          this.hookUnique('error-handler', {
            type: 'error',
            ctx: app,
            message: `Can not resolve page: ${v}`
          });
        });

        let tasks = [...pageTasks, ...componentsTask];
```
 此种方式的全局组件更符合小程序全局组件的定义，且文件也能被正常的打包到wepp文件中