### PR TITLE
fix: warning appear when bind event with wxs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,14 +22,5 @@
     "no-empty": 0,
     "yoda": 0,
     "no-new-func": 0
-  },
-  "globals": {
-    App,
-    Page,
-    wx,
-    __VERSION__,
-    Component
-  },
-  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
-  plugins: ['prettier']
+  }
 }

--- a/packages/cli/core/plugins/template/directives/v-on.js
+++ b/packages/cli/core/plugins/template/directives/v-on.js
@@ -145,6 +145,29 @@ exports = module.exports = function() {
   });
 
   this.register('template-parse-ast-attr-v-on.wxs', function({ item, name, expr, event, scope, ctx }) {
+    for (let key in item.attribs) {
+      if (item.attribs[key] === expr) {
+        let modifier = key.slice(-4);
+        if (modifier !== '.wxs') {
+          let calleeChunks = expr.split('.');
+          this.hookUnique(
+            'error-handler',
+            'template',
+            {
+              ctx: ctx,
+              message: `seems '${calleeChunks[0]}' is a wxs module, please manully add a  .wxs modifier for the event.`,
+              type: 'warn',
+              title: 'v-on'
+            },
+            {
+              item: item,
+              attr: name,
+              expr: expr
+            }
+          );
+        }
+      }
+    }
     event.expr = `{{ ${event.parsed.callee.name} }}`;
     event.proxy = false;
     event.params = event.parsed.params.map(p => {
@@ -209,22 +232,6 @@ exports = module.exports = function() {
         wxsBlock.find(item => item.attrs.module === calleeChunks[0])
       ) {
         modifiers.wxs = true;
-
-        this.hookUnique(
-          'error-handler',
-          'template',
-          {
-            ctx: ctx,
-            message: `seems '${calleeChunks[0]}' is a wxs module, please manully add a  .wxs modifier for the event.`,
-            type: 'warn',
-            title: 'v-on'
-          },
-          {
-            item: item,
-            attr: name,
-            expr: expr
-          }
-        );
       }
     }
 


### PR DESCRIPTION

- [x] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [x] cases or donate is changed or added
- [ ] documentation is changed or added
在.wpy文件中使用wxs绑定事件，
```
<wxs module="test" lang="babel">
  module.exports.tap = ()=>{
    console.log('tap')
  }
</wxs>
<template>
  <div class="container">
    <div class="userinfo" @tap.wxs="test.tap">
      <button>测试wxs点击</button>
    </div>
  </div>
</template>
````
然后进行打包的时候，不管有没有在事件后面增加.wxs的修饰符控制台都会报错，并且报错会把报错的位置，内容代码等全都展示出来。非常影响输出效率。且不管怎么修改代码都不能阻止该报错的出现。
````
 seems 'test' is a wxs module, please manully add a  .wxs modifier for the event.
````
检查代码后发现 该报错的位置并没有对是否有修饰符进行验证。

当前的pr 将报错后置到 template-parse-ast-attr-v-on.wxs 内进行，测试效果良好