### PR TITLE
修正从 app.wpy 复制 usingComponents 属性至组件的路径 bug（Windows 系统）

### DIFF
--- a/packages/cli/core/plugins/parser/config.js
+++ b/packages/cli/core/plugins/parser/config.js
@@ -61,7 +61,7 @@ exports = module.exports = function() {
           const relativePath = path.relative(path.dirname(ctx.file), targetPath);
           const parsedPath = path.parse(relativePath);
           // Remove wpy ext
-          appDefinedComponents[comp.name] = path.join(parsedPath.dir, parsedPath.name).replace(/\\/g, '/');
+          appDefinedComponents[comp.name] = slash(path.join(parsedPath.dir, parsedPath.name));
         }
       });
     }

--- a/packages/cli/core/plugins/parser/config.js
+++ b/packages/cli/core/plugins/parser/config.js
@@ -61,7 +61,7 @@ exports = module.exports = function() {
           const relativePath = path.relative(path.dirname(ctx.file), targetPath);
           const parsedPath = path.parse(relativePath);
           // Remove wpy ext
-          appDefinedComponents[comp.name] = path.join(parsedPath.dir, parsedPath.name);
+          appDefinedComponents[comp.name] = path.join(parsedPath.dir, parsedPath.name).replace(/\\/g, '/');
         }
       });
     }

--- a/packages/cli/core/plugins/scriptDepFix.js
+++ b/packages/cli/core/plugins/scriptDepFix.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const slash = require('slash');
 
 exports = module.exports = function() {
   /*
@@ -57,7 +58,7 @@ exports = module.exports = function() {
           } else if (!depMod.npm && depMod.component) {
             let relativePath = path.relative(path.dirname(parsed.file), modFilePath);
             let reg = new RegExp('\\' + this.options.wpyExt + '$', 'i');
-            relativePath = relativePath.replace(reg, '.js').replace(/\\/g, '/');
+            relativePath = slash(relativePath);
             replaceMent = `require('./${relativePath}')`;
           } else {
             if (typeof depMod.vendorId === 'number') {
@@ -72,7 +73,7 @@ exports = module.exports = function() {
               } else {
                 relativePath = path.relative(path.dirname(parsed.file), npmfile);
               }
-              relativePath = relativePath.replace(/\\/g, '/');
+              relativePath = slash(relativePath);
               replaceMent = `require('./${relativePath}')(${depMod.vendorId})`;
             } else {
               replaceMent = `require('./${dep.module}')`;

--- a/packages/cli/core/plugins/scriptDepFix.js
+++ b/packages/cli/core/plugins/scriptDepFix.js
@@ -58,7 +58,7 @@ exports = module.exports = function() {
           } else if (!depMod.npm && depMod.component) {
             let relativePath = path.relative(path.dirname(parsed.file), modFilePath);
             let reg = new RegExp('\\' + this.options.wpyExt + '$', 'i');
-            relativePath = slash(relativePath);
+            relativePath = slash(relativePath.replace(reg, '.js'));
             replaceMent = `require('./${relativePath}')`;
           } else {
             if (typeof depMod.vendorId === 'number') {

--- a/packages/cli/core/plugins/template/attrs/src.js
+++ b/packages/cli/core/plugins/template/attrs/src.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const ReplaceSource = require('webpack-sources').ReplaceSource;
 const RawSource = require('webpack-sources').RawSource;
+const slash = require('slash');
 
 exports = module.exports = function() {
   this.register('url-to-module', function urlToModule(url) {
@@ -35,7 +36,7 @@ exports = module.exports = function() {
 
       if (path.sep === '\\') {
         // It's Win, change path to posix path
-        parsed.url = parsed.url.replace(/\\/g, '/');
+        parsed.url = slash(parsed.url);
       }
 
       const code = fs.readFileSync(parsed.file, encoding);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

在 app.wpy 中的 config 里写的 `usingComponent` 路径，会被合并到每一个组件中。

使用 `path` 包中的 API，会根据操作系统的不同选择对应的路径分隔符（Windows 使用 `\`，在 JSON 中会被转义成 `\\`，在 *nix 中使用 `/`）。但微信小程序只能识别 `/`，故而找不到组件路径。

因此在 Windows 系统中使用时，遇到了问题。

可以增加一个字符串替换，将 `\` 变为 `/`，此时 Windows 路径会正确处理，*nix 不受影响。