### PR TITLE
增加类似 file-loader 的逻辑，对 require 图片地址进行处理。

### DIFF
--- a/packages/cli/core/plugins/parser/script.js
+++ b/packages/cli/core/plugins/parser/script.js
@@ -20,6 +20,11 @@ const npmTraverseFileMap = {};
 
 exports = module.exports = function() {
   this.register('wepy-parser-dep', function(node, ctx, dep) {
+    const file = dep.module;
+    if (/.(?:png|jpg|jpeg|gif|svg)$/.test(file)) {
+      return Promise.resolve(this.hookUnique('template-parse-ast-attr-src', { expr: file, ctx }).attrs.src);
+    }
+
     return this.resolvers.normal.resolve({ issuer: ctx.file }, path.dirname(ctx.file), dep.module, {}).then(rst => {
       let npm = rst.meta.descriptionFileRoot !== this.context;
 

--- a/packages/cli/core/plugins/scriptDepFix.js
+++ b/packages/cli/core/plugins/scriptDepFix.js
@@ -20,6 +20,12 @@ exports = module.exports = function() {
     parsed.parser.deps.forEach((dep, i) => {
       if (!parsed.fixedDeps[i]) {
         let depMod = parsed.depModules[i];
+        if (typeof depMod === 'string') {
+          parsed.source.replace(dep.expr.start, dep.expr.end - 1, `'${dep.module}'`);
+          parsed.fixedDeps[i] = true;
+          return;
+        }
+
         if (typeof depMod === 'number') {
           depMod = this.vendors.data(depMod);
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

Wepy 对于 template 中的 `src` 属性指定的字符串图片地址可以自动拷贝到 `weapp` 目录中的对应地址，但对于表达式就无能为力了，如：

```html
<image src="i < 5 ? imgSrc : imgExtraSrc">
```

```javascript
wepy.page({
    data: {
        imgSrc: './image1.svg',
        imgExtraSrc: './image2.svg',
    }
});
```

此时，需要使用 `static` 属性指定的文件夹才可以。

我希望对于这种情况，能增加一个类似 file-loader 的机制，如下：

```javascript
wepy.page({
    data: {
        imgSrc: require('./image1.svg'),
        imgExtraSrc: require('./image2.svg'),
    }
});
```

此时便可以对任何静态资源地址做处理。

从修改可以看出，调用了 `template-parse-ast-attr-src` 这个 hook，并对特定的文件后缀名进行处理。

修改的代码效果很勉强，逻辑也不是太好，希望能抛砖引玉，这个思路能对作者 / 其他开发者有启发，有一个更好的实现。
