### PR TITLE
Fix #2577

### DIFF
--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -50,6 +50,7 @@ class Compile extends Hook {
     this.tags = {
       htmlTags: tag.combineTag(tag.HTML_TAGS, userDefinedTags.htmlTags),
       wxmlTags: tag.combineTag(tag.WXML_TAGS, userDefinedTags.wxmlTags),
+      selfCloseTags: tag.SELF_CLOSE_TAGS,
       html2wxmlMap: tag.combineTagMap(tag.HTML2WXML_MAP, userDefinedTags.html2wxmlMap)
     };
 

--- a/packages/cli/core/plugins/template/parse.js
+++ b/packages/cli/core/plugins/template/parse.js
@@ -198,7 +198,7 @@ exports = module.exports = function() {
           let bindClass = item.bindClass && item.bindClass.length ? ` {{ [ ${item.bindClass.join(',')} ] }}` : '';
           str += ` class="${staticClass + bindClass}"`;
         }
-        console.log('this.tags.selfCloseTags', this.tags.selfCloseTags);
+        console.log('this.tags', this.tags);
         if (this.tags.selfCloseTags.includes(item.name) || (item.name === 'template' && !item.children.length)) {
           str += ' />';
         } else {

--- a/packages/cli/core/plugins/template/parse.js
+++ b/packages/cli/core/plugins/template/parse.js
@@ -198,6 +198,7 @@ exports = module.exports = function() {
           let bindClass = item.bindClass && item.bindClass.length ? ` {{ [ ${item.bindClass.join(',')} ] }}` : '';
           str += ` class="${staticClass + bindClass}"`;
         }
+        console.log('this.tags.selfCloseTags', this.tags.selfCloseTags);
         if (this.tags.selfCloseTags.includes(item.name) || (item.name === 'template' && !item.children.length)) {
           str += ' />';
         } else {

--- a/packages/cli/core/plugins/template/parse.js
+++ b/packages/cli/core/plugins/template/parse.js
@@ -198,11 +198,15 @@ exports = module.exports = function() {
           let bindClass = item.bindClass && item.bindClass.length ? ` {{ [ ${item.bindClass.join(',')} ] }}` : '';
           str += ` class="${staticClass + bindClass}"`;
         }
-        str += '>';
-        if (item.children && item.children.length) {
-          str += this.hookUnique('template-parse-ast-to-str', item.children);
+        if (this.tags.selfCloseTags.includes(item.name) || (item.name === 'template' && !item.children.length)) {
+          str += ' />';
+        } else {
+          str += '>';
+          if (item.children && item.children.length) {
+            str += this.hookUnique('template-parse-ast-to-str', item.children);
+          }
+          str += `</${item.name}>`;
         }
-        str += `</${item.name}>`;
       }
     });
     return str;

--- a/packages/cli/core/plugins/template/parse.js
+++ b/packages/cli/core/plugins/template/parse.js
@@ -198,7 +198,6 @@ exports = module.exports = function() {
           let bindClass = item.bindClass && item.bindClass.length ? ` {{ [ ${item.bindClass.join(',')} ] }}` : '';
           str += ` class="${staticClass + bindClass}"`;
         }
-        console.log('this.tags', this.tags);
         if (this.tags.selfCloseTags.includes(item.name) || (item.name === 'template' && !item.children.length)) {
           str += ' />';
         } else {

--- a/packages/cli/core/tag.js
+++ b/packages/cli/core/tag.js
@@ -55,7 +55,9 @@ const WXML_TAGS = [
   // slot
   'slot',
   // ability
-  'open-data,web-view,ad'
+  'open-data,web-view,ad',
+  // reference
+  'template,import,include'
 ]
   .join(',')
   .split(',');

--- a/packages/cli/core/tag.js
+++ b/packages/cli/core/tag.js
@@ -133,8 +133,8 @@ const combineTagMap = function(original, additional = {}) {
 exports = module.exports = {
   HTML_TAGS,
   WXML_TAGS,
-  SELF_CLOSE_TAGS,
   HTML2WXML_MAP,
+  SELF_CLOSE_TAGS,
   combineTag,
   combineTagMap
 };

--- a/packages/cli/core/tag.js
+++ b/packages/cli/core/tag.js
@@ -74,6 +74,21 @@ const HTML2WXML_MAP = {
   'wx-template': 'template'
 };
 
+const SELF_CLOSE_TAGS = [
+  'progress',
+  'checkbox',
+  'input',
+  'radio',
+  'slider',
+  'switch',
+  'textarea',
+  'live-player',
+  'live-pusher',
+  'navigation-bar',
+  'include',
+  'import'
+];
+
 /**
  * combine two tags array/object
  * @param  {Array} original original tag list
@@ -116,6 +131,7 @@ const combineTagMap = function(original, additional = {}) {
 exports = module.exports = {
   HTML_TAGS,
   WXML_TAGS,
+  SELF_CLOSE_TAGS,
   HTML2WXML_MAP,
   combineTag,
   combineTagMap

--- a/packages/cli/test/core/fixtures/template/assert/reference.wxml
+++ b/packages/cli/test/core/fixtures/template/assert/reference.wxml
@@ -1,0 +1,5 @@
+<import src="item.wxml" />
+<template is="item" data="{{text: 'forbar'}}" />
+<include src="header.wxml" />
+<view> body </view>
+<include src="footer.wxml" />

--- a/packages/cli/test/core/fixtures/template/assert/reference.wxml
+++ b/packages/cli/test/core/fixtures/template/assert/reference.wxml
@@ -1,5 +1,5 @@
 <import src="item.wxml" />
-<template is="item" data="{{text: 'forbar'}}" />
+<template is="item" data="{{text: 'foobar'}}" />
 <include src="header.wxml" />
 <view> body </view>
 <include src="footer.wxml" />

--- a/packages/cli/test/core/fixtures/template/original/reference.html
+++ b/packages/cli/test/core/fixtures/template/original/reference.html
@@ -1,0 +1,5 @@
+<import src="item.wxml" />
+<template is="item" data="{{text: 'forbar'}}" />
+<include src="header.wxml" />
+<view> body </view>
+<include src="footer.wxml" />

--- a/packages/cli/test/core/fixtures/template/original/reference.html
+++ b/packages/cli/test/core/fixtures/template/original/reference.html
@@ -1,5 +1,5 @@
 <import src="item.wxml" />
-<template is="item" data="{{text: 'forbar'}}" />
+<template is="item" data="{{text: 'foobar'}}" />
 <include src="header.wxml" />
 <view> body </view>
 <include src="footer.wxml" />

--- a/packages/cli/test/core/plugins/template/parse.test.js
+++ b/packages/cli/test/core/plugins/template/parse.test.js
@@ -91,7 +91,8 @@ function createCompiler(options = {}) {
   instance.tags = {
     htmlTags: tag.combineTag(tag.HTML_TAGS, userDefinedTags.htmlTags),
     wxmlTags: tag.combineTag(tag.WXML_TAGS, userDefinedTags.wxmlTags),
-    html2wxmlMap: tag.combineTagMap(tag.HTML2WXML_MAP, userDefinedTags.html2wxmlMap)
+    html2wxmlMap: tag.combineTagMap(tag.HTML2WXML_MAP, userDefinedTags.html2wxmlMap),
+    selfCloseTags: tag.SELF_CLOSE_TAGS
   };
   initPlugin(instance);
 

--- a/packages/cli/test/core/plugins/template/parse.test.js
+++ b/packages/cli/test/core/plugins/template/parse.test.js
@@ -35,6 +35,7 @@ const spec = {
     { file: 'bindClass' },
     { file: 'joinStyle' },
     { file: 'attrWithoutValue' },
+    { file: 'reference' },
     {
       file: 'ref',
       component: {


### PR DESCRIPTION
* 增加了自闭合标签判断
  * 翻阅了微信开发文档中的代码，总结了使用自闭合标签的标签列表。
  * 在 wepy 编译模板中，增加了判断逻辑。
  * 对于 `template` 标签既有自闭合用法和普通用法的特性，对其增加特殊逻辑判断（是否有子标签）。
* 增加了对 `template`、`import`、`include` 的支持。

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
