### PR TITLE
feat: added routed lifecycle

### DIFF
--- a/packages/core/test/mock/api/createSelectorQuery.js
+++ b/packages/core/test/mock/api/createSelectorQuery.js
@@ -1,0 +1,10 @@
+module.exports = function createSelectorQuery() {
+  return {
+    query(selector) {
+      return {
+        mock: true,
+        selector
+      };
+    }
+  };
+};

--- a/packages/core/test/mock/wxapi.js
+++ b/packages/core/test/mock/wxapi.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+class MockWxAPI {
+  constructor() {
+    this._wx = {};
+    this.init();
+  }
+
+  init() {
+    const files = fs.readdirSync(path.join(__dirname, 'api'));
+    files.forEach(file => {
+      const api = file.replace('.js', '');
+      this._wx[api] = require('./api/' + api);
+    });
+    return this;
+  }
+
+  mock(api, fn) {
+    if (arguments.length === 2) {
+      this._wx[api] = fn;
+    }
+    global.wx = this._wx;
+    return this;
+  }
+
+  unmock(api) {
+    if (api) {
+      delete this._wx[api];
+      global.wx = this._wx;
+    } else {
+      this._wx = {};
+      delete global.wx;
+    }
+    return this;
+  }
+}
+
+module.exports = MockWxAPI;

--- a/packages/core/test/weapp/init/lifecycle.test.js
+++ b/packages/core/test/weapp/init/lifecycle.test.js
@@ -1,8 +1,26 @@
 const expect = require('chai').expect;
-import { getLifeCycle } from '../../../weapp/init';
+import { getLifeCycle, patchAppLifecycle, patchLifecycle } from '../../../weapp/init';
 import { WEAPP_APP_LIFECYCLE } from '../../../shared';
 
+import MockWxAPI from '../../mock/wxapi';
+
+const mockapi = new MockWxAPI();
+
+const allPages = [];
+const pageIndex = -1;
+
 describe('weapp life cycles', () => {
+  before(() => {
+    mockapi.mock();
+
+    global.getCurrentPages = function() {
+      return allPages;
+    };
+  });
+  after(() => {
+    mockapi.unmock();
+  });
+
   it('should add wepy.app life cycles for string', () => {
     const rel = {
       lifecycle: {
@@ -10,10 +28,7 @@ describe('weapp life cycles', () => {
       }
     };
     const lifeCycles = getLifeCycle(WEAPP_APP_LIFECYCLE, rel, 'app');
-    expect(lifeCycles).to.deep.equal([
-      ...WEAPP_APP_LIFECYCLE,
-      'onSomeNewFeature'
-    ]);
+    expect(lifeCycles).to.deep.equal([...WEAPP_APP_LIFECYCLE, 'onSomeNewFeature']);
   });
 
   it('should add wepy.app life cycles for array', () => {
@@ -23,26 +38,146 @@ describe('weapp life cycles', () => {
       }
     };
     const lifeCycles = getLifeCycle(WEAPP_APP_LIFECYCLE, rel, 'app');
-    expect(lifeCycles).to.deep.equal([
-      ...WEAPP_APP_LIFECYCLE,
-      'onSomeNewFeature1',
-      'onSomeNewFeature2'
-    ]);
+    expect(lifeCycles).to.deep.equal([...WEAPP_APP_LIFECYCLE, 'onSomeNewFeature1', 'onSomeNewFeature2']);
   });
 
   it('should modify wepy.app life cycles for function', () => {
     const rel = {
       lifecycle: {
-        app: function (lifecycles) {
+        app: function(lifecycles) {
           const newLifeCycles = lifecycles.filter(l => l !== 'onError');
           return [...newLifeCycles, 'onSomeNewFeature'];
         }
       }
     };
     const lifeCycles = getLifeCycle(WEAPP_APP_LIFECYCLE, rel, 'app');
-    expect(lifeCycles).to.deep.equal([
-      ...WEAPP_APP_LIFECYCLE.filter(l => l !== 'onError'),
-      'onSomeNewFeature'
-    ]);
+    expect(lifeCycles).to.deep.equal([...WEAPP_APP_LIFECYCLE.filter(l => l !== 'onError'), 'onSomeNewFeature']);
+  });
+
+  it('patchAppLifecycle', () => {
+    const runState = {
+      onLaunch1: false,
+      onLaunch2: false,
+      onShow: false
+    };
+    const appInstance = {};
+    const appConfig = {};
+    const options = {
+      onShow() {
+        runState.onShow = true;
+      },
+      onLaunch: [
+        () => {
+          runState.onLaunch1 = true;
+        },
+        () => {
+          runState.onLaunch2 = true;
+        }
+      ]
+    };
+    const rel = {};
+
+    patchAppLifecycle(appConfig, options, rel);
+
+    expect(appConfig.onLaunch).is.a('function');
+    expect(appConfig.onShow).is.a('function');
+
+    expect(appConfig.onError).is.a('undefined');
+
+    appConfig.onLaunch.call(appInstance);
+
+    appConfig.onShow.call(appInstance);
+
+    for (const k in runState) {
+      expect(runState[k]).to.be.equal(true);
+    }
+  });
+
+  it('patchLifecycle componennt', () => {
+    const runState = {
+      ready: false
+    };
+    const compInstance = {};
+    const output = { methods: {} };
+    const options = {
+      ready() {
+        runState.ready = true;
+      }
+    };
+    const rel = {};
+
+    patchLifecycle(output, options, rel, true);
+
+    expect(output.created).is.a('function');
+
+    output.created.call(compInstance);
+
+    output.ready.call(compInstance);
+
+    expect(runState.ready).to.equal(true);
+  });
+
+  it('patchLifecycle page', () => {
+    const runState = {
+      routed: false,
+      testPageRouted: false
+    };
+    const indexPage = {
+      is: 'somepage',
+      route: 'pages/index',
+      __wxExparserNodeId__: '29d1dad1',
+      __wxWebviewId__: 1
+    };
+    const output = { methods: {} };
+    const options = {
+      routed(oldRoute, newRoute) {
+        expect(oldRoute).to.equal(null);
+        expect(newRoute.path).to.equal(indexPage.route);
+        runState.routed = true;
+      }
+    };
+    const rel = {};
+
+    patchLifecycle(output, options, rel, false);
+
+    expect(output.created).is.a('function');
+    expect(output.attached).is.a('function');
+
+    output.created.call(indexPage);
+    output.attached.call(indexPage);
+
+    allPages.push(indexPage);
+
+    output.methods.onShow.call(indexPage);
+
+    expect(runState.routed).to.equal(true);
+
+    const testPage = {
+      is: 'testpage',
+      route: 'pages/test',
+      __wxExparserNodeId__: '29d2dad2',
+      __wxWebviewId__: 2
+    };
+    const testOutput = { methods: {} };
+    const testOutputOptions = {
+      routed(oldRoute, newRoute) {
+        expect(oldRoute.path).to.equal(indexPage.route);
+        expect(newRoute.path).to.equal(testPage.route);
+        runState.testPageRouted = true;
+      }
+    };
+
+    patchLifecycle(testOutput, testOutputOptions, rel, false);
+
+    testOutput.created.call(testPage);
+    testOutput.attached.call(testPage);
+
+    allPages.push(testPage);
+
+    testOutput.methods.onShow.call(testPage);
+
+    for (const k in runState) {
+      expect(runState[k]).to.be.equal(true);
+    }
   });
 });

--- a/packages/core/test/weapp/observer/observerPath.test.js
+++ b/packages/core/test/weapp/observer/observerPath.test.js
@@ -55,7 +55,6 @@ describe('weapp observer observerPath', function() {
     initData(vm, { a: { b: { c: { d: 123 } } }, x: {}, y: {} });
 
     // eslint-disable-next-line
-    console.log('complex path: Object');
     const data = vm._data;
     data.x = data.a.b.c;
     data.y = data.x;

--- a/packages/core/weapp/init/lifecycle.js
+++ b/packages/core/weapp/init/lifecycle.js
@@ -66,7 +66,7 @@ export function patchAppLifecycle(appConfig, options, rel = {}) {
     let vm = new WepyApp();
     app = vm;
     vm.$options = options;
-    vm.$route = {};
+    vm.$route = null; // default route is null
     vm.$rel = rel;
 
     vm.$wx = this;
@@ -150,115 +150,12 @@ export function patchLifecycle(output, options, rel, isComponent) {
 
   output.created = initLifecycle;
   if (isComponent) {
-    output.attached = function(...args) {
-      // Component attached
-      let outProps = output.properties || {};
-      // this.propperties are includes datas
-      let acceptProps = this.properties;
-      let vm = this.$wepy;
-
-      this.triggerEvent('_init', vm);
-
-      // created 不能调用 setData，如果有 dirty 在此更新
-      vm.$forceUpdate();
-
-      Object.keys(outProps).forEach(k => (vm[k] = acceptProps[k]));
-
-      return callUserMethod(vm, vm.$options, 'attached', args);
-    };
-
-    // 增加组件页面声明周期
-    output.pageLifetimes = {};
-    const lifecycle = getLifeCycle(WEAPP_COMPONENT_PAGE_LIFECYCLE, rel, 'component');
-
-    lifecycle.forEach(function(k) {
-      if (!output.pageLifetimes[k] && options[k] && (isFunc(options[k]) || isArr(options[k]))) {
-        output.pageLifetimes[k] = function(...args) {
-          return callUserMethod(this.$wepy, this.$wepy.$options, k, args);
-        };
-      }
-    });
+    patchComponentLifecycle(output, options, rel);
   } else {
-    output.attached = function(...args) {
-      // Page attached
-      let vm = this.$wepy;
-      let app = vm.$app;
-      // eslint-disable-next-line
-      let pages = getCurrentPages();
-      let currentPage = pages[pages.length - 1];
-      let path = currentPage.__route__;
-      let webViewId = currentPage.__wxWebviewId__;
-
-      let refs = rel.refs || [];
-      let query = wx.createSelectorQuery();
-
-      refs.forEach(item => {
-        // {
-        //   id: { name: 'hello', bind: true },
-        //   ref: { name: 'value', bind: false }
-        // }
-        let idAttr = item.id;
-        let refAttr = item.ref;
-        let actualAttrIdName = idAttr.name;
-        let actualAttrRefName = refAttr.name;
-        let selector = `#${actualAttrIdName}`;
-
-        if (idAttr.bind) {
-          // if id is a bind attr
-          actualAttrIdName = vm[idAttr.name];
-          selector = `#${actualAttrIdName}`;
-          vm.$watch(idAttr.name, function(newAttrName) {
-            actualAttrIdName = newAttrName;
-            selector = `#${actualAttrIdName}`;
-            vm.$refs[actualAttrRefName] = query.select(selector);
-          });
-        }
-
-        if (refAttr.bind) {
-          // if ref is a bind attr
-          actualAttrRefName = vm[refAttr.name];
-
-          vm.$watch(refAttr.name, function(newAttrName, oldAttrName) {
-            actualAttrRefName = newAttrName;
-            vm.$refs[oldAttrName] = null;
-            vm.$refs[newAttrName] = query.select(selector);
-          });
-        }
-        vm.$refs[actualAttrRefName] = query.select(selector);
-      });
-
-      // created 不能调用 setData，如果有 dirty 在此更新
-      vm.$forceUpdate();
-
-      if (app.$route.path !== path) {
-        app.$route.path = path;
-        app.$route.webViewId = webViewId;
-        vm.routed && vm.routed();
-      }
-
-      // TODO: page attached
-      return callUserMethod(vm, vm.$options, 'attached', args);
-    };
-    // Page lifecycle will be called under methods
-    // e.g:
-    // Component({
-    //   methods: {
-    //     onLoad () {
-    //       console.log('page onload')
-    //     }
-    //   }
-    // })
-
-    let lifecycle = getLifeCycle(WEAPP_PAGE_LIFECYCLE, rel, 'page');
-
-    lifecycle.forEach(k => {
-      if (!output[k] && options[k] && (isFunc(options[k]) || isArr(options[k]))) {
-        output.methods[k] = function(...args) {
-          return callUserMethod(this.$wepy, this.$wepy.$options, k, args);
-        };
-      }
-    });
+    patchPageLifecycle(output, options, rel);
   }
+
+  // Common patch
   let lifecycle = getLifeCycle(WEAPP_COMPONENT_LIFECYCLE, rel, 'component');
 
   lifecycle.forEach(k => {
@@ -269,4 +166,152 @@ export function patchLifecycle(output, options, rel, isComponent) {
       };
     }
   });
+}
+
+/**
+ * Patch component life cycle
+ * @param {*} output patch output
+ * @param {*} options patch options
+ * @param {*} rel patch rel
+ */
+function patchComponentLifecycle(output, options, rel) {
+  output.attached = function(...args) {
+    // Component attached
+    let outProps = output.properties || {};
+    // this.propperties are includes datas
+    let acceptProps = this.properties;
+    let vm = this.$wepy;
+
+    this.triggerEvent('_init', vm);
+
+    // created 不能调用 setData，如果有 dirty 在此更新
+    vm.$forceUpdate();
+
+    Object.keys(outProps).forEach(k => (vm[k] = acceptProps[k]));
+
+    return callUserMethod(vm, vm.$options, 'attached', args);
+  };
+
+  // 增加组件页面声明周期
+  output.pageLifetimes = {};
+  const lifecycle = getLifeCycle(WEAPP_COMPONENT_PAGE_LIFECYCLE, rel, 'component');
+
+  lifecycle.forEach(function(k) {
+    if (!output.pageLifetimes[k] && options[k] && (isFunc(options[k]) || isArr(options[k]))) {
+      output.pageLifetimes[k] = function(...args) {
+        return callUserMethod(this.$wepy, this.$wepy.$options, k, args);
+      };
+    }
+  });
+}
+
+/**
+ * Patch Page Life cycle
+ * @param {*} output patch output
+ * @param {*} options patch options
+ * @param {*} rel rel
+ */
+function patchPageLifecycle(output, options, rel) {
+  output.attached = function(...args) {
+    // Page attached
+    let vm = this.$wepy;
+    let app = vm.$app;
+
+    let refs = rel.refs || [];
+    let query = wx.createSelectorQuery();
+
+    refs.forEach(item => {
+      // {
+      //   id: { name: 'hello', bind: true },
+      //   ref: { name: 'value', bind: false }
+      // }
+      let idAttr = item.id;
+      let refAttr = item.ref;
+      let actualAttrIdName = idAttr.name;
+      let actualAttrRefName = refAttr.name;
+      let selector = `#${actualAttrIdName}`;
+
+      if (idAttr.bind) {
+        // if id is a bind attr
+        actualAttrIdName = vm[idAttr.name];
+        selector = `#${actualAttrIdName}`;
+        vm.$watch(idAttr.name, function(newAttrName) {
+          actualAttrIdName = newAttrName;
+          selector = `#${actualAttrIdName}`;
+          vm.$refs[actualAttrRefName] = query.select(selector);
+        });
+      }
+
+      if (refAttr.bind) {
+        // if ref is a bind attr
+        actualAttrRefName = vm[refAttr.name];
+
+        vm.$watch(refAttr.name, function(newAttrName, oldAttrName) {
+          actualAttrRefName = newAttrName;
+          vm.$refs[oldAttrName] = null;
+          vm.$refs[newAttrName] = query.select(selector);
+        });
+      }
+      vm.$refs[actualAttrRefName] = query.select(selector);
+    });
+
+    // created 不能调用 setData，如果有 dirty 在此更新
+    vm.$forceUpdate();
+
+    // TODO: page attached
+    return callUserMethod(vm, vm.$options, 'attached', args);
+  };
+  // Page lifecycle will be called under methods
+  // e.g:
+  // Component({
+  //   methods: {
+  //     onLoad () {
+  //       console.log('page onload')
+  //     }
+  //   }
+  // })
+
+  // Patch routed method
+  patchRouted(output);
+
+  let lifecycle = getLifeCycle(WEAPP_PAGE_LIFECYCLE, rel, 'page');
+
+  lifecycle.forEach(k => {
+    if (!output[k] && options[k] && (isFunc(options[k]) || isArr(options[k]))) {
+      // onShow is patched in routed method
+      if (k !== 'onShow') {
+        output.methods[k] = function(...args) {
+          return callUserMethod(this.$wepy, this.$wepy.$options, k, args);
+        };
+      }
+    }
+  });
+}
+/**
+ * Add routed method for user.
+ * @param {*} output patch output
+ */
+function patchRouted(output) {
+  output.methods.onShow = function(...args) {
+    // Page attached
+    let vm = this.$wepy;
+    let app = vm.$app;
+    // eslint-disable-next-line
+    const pages = getCurrentPages();
+    const currentPage = pages[pages.length - 1];
+    const path = currentPage.__route__ || currentPage.route;
+    const webViewId = currentPage.__wxWebviewId__;
+
+    if (!app.$route || app.$route.path !== path) {
+      const oldRoute = app.$route;
+      const newRoute = {
+        path,
+        webViewId,
+        page: currentPage,
+        query: currentPage.options
+      };
+      app.$route = newRoute;
+      callUserMethod(vm, vm.$options, 'routed', [oldRoute, newRoute]);
+    }
+  };
 }


### PR DESCRIPTION
Used to handle page route events.

navigate or navigateBack will both trigger this event.


```
wepy.page({
  // If it's the first time to enter a page, then previous route is null
  routed(previousRoute, currentRoute) {
     console.log(`Routed event triggerd: ${previousRoute === null ? 'Started' : previousRoute.path} -> ${currentRoute.path}`);
  }
})
```


PS: test cases included.
