### PR TITLE
支持 windows 下的 npm run test:cov 命令

### DIFF
--- a/test/unit.js
+++ b/test/unit.js
@@ -30,7 +30,8 @@ function testAll(pkgs) {
 
 function testOne(name) {
   process.env.FORCE_COLOR = 1;
-  const result = spawnSync('npm', ['run', 'test'], {
+  const command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const result = spawnSync(command, ['run', 'test'], {
     cwd: path.join(process.cwd(), 'packages', name),
     env: process.env,
     stdio: 'inherit'


### PR DESCRIPTION
在 windows 下 npm 的执行名不同。

这里判断了一下平台。

- [x] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added

