### PR TITLE
因小程序canvas无法接受bind:绑定事件 修改v-on的parseHandler

### DIFF
--- a/packages/cli/core/plugins/template/directives/v-on.js
+++ b/packages/cli/core/plugins/template/directives/v-on.js
@@ -110,7 +110,11 @@ const parseHandler = (name = '', value = '', scope) => {
   info = parseHandlerProxy(value, scope);
 
   if (name === 'click') name = 'tap';
-  type = 'bind:' + name;
+  if (name.startsWith("touch")) {
+    type = 'bind' + name;
+  } else {
+    type = 'bind:' + name;
+  }
   return {
     event: name,
     type: type,


### PR DESCRIPTION
因小程序canvas无法接受bind:绑定事件 修改v-on的parseHandler 在touch相关事件使用bindtouch***