### PR TITLE
【hotfix】live-player & live-pusher 是双标签不是单标签

### DIFF
--- a/packages/cli/core/tag.js
+++ b/packages/cli/core/tag.js
@@ -84,8 +84,6 @@ const SELF_CLOSE_TAGS = [
   'slider',
   'switch',
   'textarea',
-  'live-player',
-  'live-pusher',
   'navigation-bar',
   'include',
   'import'


### PR DESCRIPTION
live-player & live-pusher 是双标签不是单标签
单标签无法包裹cover-view 有场景需要在组件内添加内容
