### PR TITLE
fix: 修复配置插件页面时报错情况

### DIFF
--- a/packages/cli/core/compile.js
+++ b/packages/cli/core/compile.js
@@ -27,6 +27,13 @@ const initCompiler = require('./init/compiler');
 const initParser = require('./init/parser');
 const initPlugin = require('./init/plugin');
 
+// 过滤出合法的页面路径
+// fix issue: https://github.com/Tencent/wepy/issues/2708
+function filterPagePath(pagePath) {
+  // 这里暂时只考虑过滤 __plugin__/ 开头的页面路径
+  return pagePath.indexOf('__plugin__/') !== 0;
+}
+
 class Compile extends Hook {
   constructor(opt) {
     super();
@@ -206,7 +213,7 @@ class Compile extends Hook {
             message: `Missing "pages" in App config`
           });
         }
-        let pages = appConfig.pages.map(v => {
+        let pages = appConfig.pages.filter(filterPagePath).map(v => {
           return path.resolve(app.file, '..', v);
         });
 
@@ -220,7 +227,7 @@ class Compile extends Hook {
               throw new Error('EXIT');
             }
 
-            sub.pages.forEach(v => {
+            sub.pages.filter(filterPagePath).forEach(v => {
               pages.push(path.resolve(app.file, '../' + sub.root || '', v));
             });
           });


### PR DESCRIPTION
修复 app.wpy 中添加插件页面路径时的报错。

- 在 pages 遍历之前过滤插件页面路径
- 在分包的 pages 遍历之前过滤插件页面路径

Issue #2710
Closes #2710

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] tests and/or benchmarks are included
- [x] cases or donate is changed or added
- [x] documentation is changed or added
