### PR TITLE
修复ts import不能简写为目录名的问题

### DIFF
--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -147,7 +147,7 @@ export default {
                 ext = '.js';
             } else if (util.isFile(source + '.ts')) {
                 ext = '.ts';
-            } else if (util.isDir(source) && util.isFile(source + path.sep + 'index.js')) {
+            } else if (util.isDir(source) && (util.isFile(source + path.sep + 'index.js') || util.isFile(source + path.sep + 'index.ts'))) {
                 ext = path.sep + 'index.js';
             }else if (util.isFile(source)) {
                 ext = '';

--- a/packages/wepy-cli/src/web/compile-script.js
+++ b/packages/wepy-cli/src/web/compile-script.js
@@ -147,7 +147,7 @@ export default {
                     source += '.js';
                 } else if (util.isFile(source + '.ts')) {
                     source += '.js';
-                } else if (util.isDir(source) && util.isFile(source + path.sep + 'index.js')) {
+                } else if (util.isDir(source) && (util.isFile(source + path.sep + 'index.js') || util.isFile(source + path.sep + 'index.ts'))) {
                     source += path.sep + 'index.js';
                 } else {
                     throw `Missing files: ${resolved} in ${wpy.script.src}`;

--- a/packages/wepy-compiler-typescript/package.json
+++ b/packages/wepy-compiler-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wepy-compiler-typescript",
-  "version": "1.5.9",
+  "version": "2.0.0",
   "description": "wepy compile typescript",
   "main": "lib/index.js",
   "scripts": {
@@ -12,6 +12,6 @@
   "author": "Gcaufy",
   "license": "MIT",
   "dependencies": {
-    "typescript": "^2.1.4"
+    "typescript": "^4.3.2"
   }
 }


### PR DESCRIPTION
目录结构如下：
```
.
├── other.ts
├── test
│   └── index.ts
```

other.ts代码如下：

```typescript
import { test } from './test';  // 报错
import { test } from './test/index';  // ok
```

#### 问题
在ts里，import 简写为目录名'./test'时报错`[Error] Missing files: ./test in /xxxxxxx/other.ts`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
