### PR TITLE
refactor(wepy): $dirty 调用时机由 Observer 改到 Watcher，解耦 RenderWatcher 和 O…

### DIFF
--- a/packages/core/test/weapp/class/Dirty.js
+++ b/packages/core/test/weapp/class/Dirty.js
@@ -1,14 +1,22 @@
 import { initData } from '../../../weapp/init/data';
 import Dirty from '../../../weapp/class/Dirty';
+import { initRender } from '../../../weapp/init/render';
 
 const expect = require('chai').expect;
 
 describe('weapp class Dirty', function() {
   it('test dirty path', () => {
-    const vm = {};
+    const vm = {
+      _watchers: []
+    };
     vm.$dirty = new Dirty('path');
 
     initData(vm, { list: [], num: 1, arr: [1, 2], complex: { a: 1, arr: [100, { x: [0, 1, { b: 1 }] }] } });
+    initRender(
+      vm,
+      Object.keys(vm._data),
+      Object.keys({})
+    );
 
     vm.num = 2;
     expect(vm.$dirty.length()).to.be.equal(1);
@@ -49,10 +57,17 @@ describe('weapp class Dirty', function() {
   });
 
   it('test dirty key', () => {
-    const vm = {};
+    const vm = {
+      _watchers: []
+    };
     vm.$dirty = new Dirty('key');
 
     initData(vm, { num: 1, arr: [1, 2], complex: { a: 1, arr: [100, { x: [0, 1, { b: 1 }] }] } });
+    initRender(
+      vm,
+      Object.keys(vm._data),
+      Object.keys({})
+    );
 
     vm.num = 2;
     expect(vm.$dirty.length()).to.be.equal(1);

--- a/packages/core/weapp/class/Dirty.js
+++ b/packages/core/weapp/class/Dirty.js
@@ -35,7 +35,7 @@ export default class Dirty {
   /**
    * Set dirty from a ObserverPath
    */
-  set(op, key, value) {
+  set(op, key, value, vm) {
     let pathMap;
     let pathKeys;
     // eslint-disable-next-line eqeqeq
@@ -53,7 +53,7 @@ export default class Dirty {
      * 因此不需要所有 path 都 setData 。
      */
     const { root, path } = pathMap[pathKeys[0]];
-    this.push(root, path, root === path ? value : op.ob.vm[root], value);
+    this.push(root, path, root === path ? value : vm[root], value);
   }
 
   reset() {

--- a/packages/core/weapp/class/WepyComponent.js
+++ b/packages/core/weapp/class/WepyComponent.js
@@ -2,7 +2,7 @@ import Base from './Base';
 import Watcher from '../observer/watcher';
 import { isArr, isPlainObject } from '../../shared/index';
 
-import { renderNextTick } from '../util/next-tick';
+import { renderNextTick, nextTick } from '../util/next-tick';
 
 export default class WepyComponent extends Base {
   $watch(expOrFn, cb, options) {
@@ -24,7 +24,9 @@ export default class WepyComponent extends Base {
     options.user = true;
     let watcher = new Watcher(vm, expOrFn, cb, options);
     if (options.immediate) {
-      cb.call(vm, watcher.value);
+      nextTick(function() {
+        cb.call(vm, watcher.value);
+      });
     }
     return function unwatchFn() {
       watcher.teardown();

--- a/packages/core/weapp/observer/array.js
+++ b/packages/core/weapp/observer/array.js
@@ -39,23 +39,21 @@ methodsToPatch.forEach(function(method) {
 
     const result = original.apply(this, args);
     const ob = this.__ob__;
-    const vm = ob.vm;
 
-    // push parent key to dirty, wait to setData
-    if (vm.$dirty) {
-      if (method === 'push') {
-        const lastIndex = ob.value.length - 1;
-        vm.$dirty.set(ob.op, lastIndex, ob.value[lastIndex]);
-      } else {
-        vm.$dirty.set(ob.op, null, ob.value);
-      }
+    let dirtyData;
+
+    if (method === 'push') {
+      const lastIndex = ob.value.length - 1;
+      dirtyData = { op: ob.op, key: lastIndex, value: ob.value[lastIndex] }
+    } else {
+      dirtyData = { op: ob.op, key: null, value: ob.value }
     }
 
     // 这里和 vue 不一样，所有变异方法都需要更新 path
     ob.observeArray(ob.key, ob.value);
 
     // notify change
-    ob.dep.notify();
+    ob.dep.notify({ dirtyData });
     return result;
   });
 });

--- a/packages/core/weapp/observer/dep.js
+++ b/packages/core/weapp/observer/dep.js
@@ -27,11 +27,11 @@ export default class Dep {
     }
   }
 
-  notify() {
+  notify(obj) {
     // stabilize the subscriber list first
     const subs = this.subs.slice();
     for (let i = 0, l = subs.length; i < l; i++) {
-      subs[i].update();
+      subs[i].update(obj);
     }
   }
 }

--- a/packages/core/weapp/observer/watcher.js
+++ b/packages/core/weapp/observer/watcher.js
@@ -124,7 +124,11 @@ export default class Watcher {
    * Subscriber interface.
    * Will be called when a dependency changes.
    */
-  update() {
+  update(obj = {}) {
+    if (this.isRenderWatcher && obj.dirtyData) {
+      this.vm.$dirty.set(obj.dirtyData.op, obj.dirtyData.key, obj.dirtyData.value, this.vm)
+    }
+
     /* istanbul ignore else */
     if (this.computed) {
       this.dirty = true;


### PR DESCRIPTION
Observer 之所以会引用 vm，是为了响应数据被修改时，把修改信息放入 vm.$dirty。
其实可以换个思路。把修改信息通过 notify 往上传给Watcher，由Watcher调用 vm.$dirty。

除了解决 GC 之外，还解决了另一个问题，响应数据和关联的第一个 vm 耦合。
举个例子，有一个 obj。
pageA.data.a = obj。pageB.data.b = obj。
obj.x = 123，只有页面 A 会更新，而页面 B 无法更新，因为 obj 引用的 vm 是 PagaA

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
