### PR TITLE
Remove david-dm from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![travis-ci](https://travis-ci.org/Tencent/wepy.svg?branch=1.7.x)](https://travis-ci.org/Tencent/wepy)
 ![Github CI](https://github.com/Tencent/wepy/workflows/WePY%20CI%20Build/badge.svg?branch=2.0.x)
 [![Coverage Status](https://coveralls.io/repos/github/Tencent/wepy/badge.svg?branch=1.7.x)](https://coveralls.io/github/Tencent/wepy?branch=1.7.x)
-[![Dependency Status](https://david-dm.org/Tencent/wepy.svg)](https://david-dm.org/Tencent/wepy)
 
 ### 介绍
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,7 +6,6 @@ English | [简体中文](./README.md)
 [![travis-ci](https://travis-ci.org/Tencent/wepy.svg?branch=1.7.x)](https://travis-ci.org/Tencent/wepy)
 ![Github CI](https://github.com/Tencent/wepy/workflows/WePY%20CI%20Build/badge.svg?branch=2.0.x)
 [![Coverage Status](https://coveralls.io/repos/github/Tencent/wepy/badge.svg?branch=1.7.x)](https://coveralls.io/github/Tencent/wepy?branch=1.7.x)
-[![Dependency Status](https://david-dm.org/Tencent/wepy.svg)](https://david-dm.org/Tencent/wepy)
 
 ### Introduce
 


### PR DESCRIPTION
The `david-dm.org` website is down for 3 months, and the project `alanshaw/david` is not actively maintained anymore. `david-dm.org` should be considered dead, thus badges should be removed from README.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [x] documentation is changed or added
